### PR TITLE
Disable SSLv2 by default and optimize memory usage

### DIFF
--- a/src/LibsslTLSContext.cc
+++ b/src/LibsslTLSContext.cc
@@ -55,7 +55,14 @@ TLSContext::TLSContext()
     A2_LOG_ERROR(fmt("SSL_CTX_new() failed. Cause: %s",
                      ERR_error_string(ERR_get_error(), 0)));
   }
+  /* Disable SSLv2 and enable all workarounds for buggy servers */
+  SSL_CTX_set_options(sslCtx_, SSL_OP_ALL|SSL_OP_NO_SSLv2);
   SSL_CTX_set_mode(sslCtx_, SSL_MODE_AUTO_RETRY);
+  #ifdef SSL_MODE_RELEASE_BUFFERS
+  /* keep memory usage low */
+  SSL_CTX_set_mode(sslCtx_, SSL_MODE_RELEASE_BUFFERS);
+  #endif
+  
 }
 
 TLSContext::~TLSContext()


### PR DESCRIPTION
- Disable SSLv2 and enable all workarounds for buggy servers
- Keep memory usage low when openSSL supports SSL_MODE_RELEASE_BUFFERS
