### PR TITLE
Do not reference RequestGroups longer than necessary

### DIFF
--- a/src/MultiUrlRequestInfo.cc
+++ b/src/MultiUrlRequestInfo.cc
@@ -104,7 +104,7 @@ void handler(int signal) {
 } // namespace
 
 MultiUrlRequestInfo::MultiUrlRequestInfo
-(const std::vector<SharedHandle<RequestGroup> >& requestGroups,
+(std::vector<SharedHandle<RequestGroup> >& requestGroups,
  const SharedHandle<Option>& op,
  const SharedHandle<StatCalc>& statCalc,
  const SharedHandle<OutputFile>& summaryOut,
@@ -158,6 +158,8 @@ error_code::Value MultiUrlRequestInfo::execute()
 
     SharedHandle<DownloadEngine> e =
       DownloadEngineFactory().newDownloadEngine(option_.get(), requestGroups_);
+    // Avoid keeping RequestGroups alive longer than necessary
+    requestGroups_.clear();
 
     if(!option_->blank(PREF_LOAD_COOKIES)) {
       File cookieFile(option_->get(PREF_LOAD_COOKIES));

--- a/src/MultiUrlRequestInfo.h
+++ b/src/MultiUrlRequestInfo.h
@@ -52,7 +52,7 @@ class UriListParser;
 
 class MultiUrlRequestInfo {
 private:
-  std::vector<SharedHandle<RequestGroup> > requestGroups_;
+  std::vector<SharedHandle<RequestGroup> >& requestGroups_;
 
   SharedHandle<Option> option_;
 
@@ -64,8 +64,12 @@ private:
 
   void printMessageForContinue();
 public:
+  /*
+   * MultiRequestInfo effectively takes ownership of the
+   * requestGroups.
+   */
   MultiUrlRequestInfo
-  (const std::vector<SharedHandle<RequestGroup> >& requestGroups,
+  (std::vector<SharedHandle<RequestGroup> >& requestGroups,
    const SharedHandle<Option>& op,
    const SharedHandle<StatCalc>& statCalc,
    const SharedHandle<OutputFile>& summaryOut,


### PR DESCRIPTION
There is an initial vector of SharedHandle<RequestGroup> to seed the
DownloadEngine. This vector was however kept alive via main.cc ->
MultiUrlRequestInfo up until the program exits, hence effetively leaking
all initial RequestGroups and associated object instances.

Hence, as a matter of dirty-workaround, drop the contents of that initial
vector as soon as it is not required any longer.
