### PR TITLE
Check for sys/signal.h and/or signal.h (Take 2)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -364,6 +364,7 @@ AC_CHECK_HEADERS([argz.h \
                   netinet/tcp.h \
 		  poll.h \
 		  port.h \
+                  signal.h \
                   stddef.h \
                   stdint.h \
                   stdio_ext.h \
@@ -372,6 +373,7 @@ AC_CHECK_HEADERS([argz.h \
                   strings.h \
                   sys/ioctl.h \
                   sys/param.h \
+                  sys/signal.h \
                   sys/socket.h \
                   sys/time.h \
                   sys/types.h \

--- a/src/util.cc
+++ b/src/util.cc
@@ -34,7 +34,14 @@
 /* copyright --> */
 #include "util.h"
 
-#include <sys/signal.h>
+#ifdef HAVE_SYS_SIGNAL_H
+#  include <sys/signal.h>
+#else // HAVE_SYS_SIGNAL_H
+#  ifdef HAVE_SIGNAL_H
+#    include <signal.h>
+#  endif // HAVE_SIGNAL_H
+#endif // HAVE_SYS_SIGNAL_H
+
 #include <sys/types.h>
 #ifdef HAVE_PWD_H
 #  include <pwd.h>


### PR DESCRIPTION
mingw-w64 does not actually have sys/signal.h, while OSX currently has a
broken signal.h
Better check the presence of both and use sys/signal.h if present, else
signal.h
