### PR TITLE
Make configure argument meaning more consistent and obvious.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -24,20 +24,20 @@ esac
 AC_DEFINE_UNQUOTED([TARGET], ["$target"], [Define target-type])
 
 # Checks for arguments.
-ARIA2_ARG_WITH([gnutls])
-ARIA2_ARG_WITH([libnettle])
-ARIA2_ARG_WITH([libgmp])
-ARIA2_ARG_WITH([libgcrypt])
-ARIA2_ARG_WITH([openssl])
-ARIA2_ARG_WITH([sqlite3])
-ARIA2_ARG_WITH([libxml2])
-ARIA2_ARG_WITH([libexpat])
-ARIA2_ARG_WITH([libcares])
-ARIA2_ARG_WITH([libz])
+ARIA2_ARG_WITHOUT([gnutls])
+ARIA2_ARG_WITHOUT([libnettle])
+ARIA2_ARG_WITHOUT([libgmp])
+ARIA2_ARG_WITHOUT([libgcrypt])
+ARIA2_ARG_WITHOUT([openssl])
+ARIA2_ARG_WITHOUT([sqlite3])
+ARIA2_ARG_WITHOUT([libxml2])
+ARIA2_ARG_WITHOUT([libexpat])
+ARIA2_ARG_WITHOUT([libcares])
+ARIA2_ARG_WITHOUT([libz])
 
-ARIA2_ARG_ENABLE([bittorrent])
-ARIA2_ARG_ENABLE([metalink])
-ARIA2_ARG_ENABLE([epoll])
+ARIA2_ARG_DISABLE([bittorrent])
+ARIA2_ARG_DISABLE([metalink])
+ARIA2_ARG_DISABLE([epoll])
 
 AC_ARG_WITH([ca-bundle],
   AS_HELP_STRING([--with-ca-bundle=FILE],[Use FILE as default CA bundle.]),
@@ -48,7 +48,7 @@ AC_ARG_WITH([bashcompletiondir],
                  [Directory to install bash_completion file]),
   [bashcompletiondir=$withval], [bashcompletiondir=$docdir/bash_completion])
 
-AC_ARG_VAR([ARIA2_STATIC], [Set `yes' to build a statically linked aria2])
+AC_ARG_VAR([ARIA2_STATIC], [Set 'yes' to build a statically linked aria2])
 
 # Checks for programs.
 AC_PROG_CXX

--- a/m4/aria2_arg.m4
+++ b/m4/aria2_arg.m4
@@ -1,18 +1,34 @@
 dnl ARIA2_ARG_WITH(PACKAGE)
-dnl wrapper for AC_ARG_WITH with default value 'yes'.
+dnl wrapper for AC_ARG_WITH with default value 'no'.
 dnl If --with-$1 is given explicitly, set with_$1_requested to given value.
 AC_DEFUN([ARIA2_ARG_WITH],
 [AC_ARG_WITH([$1],
-	AS_HELP_STRING([--with-$1], [Use $1 if it is installed.]),
+	AS_HELP_STRING([--with-$1], [Use $1.]),
+	[with_$1_requested=$withval with_$1=$withval], [with_$1=no])]
+)
+dnl ARIA2_ARG_WITH(PACKAGE)
+dnl wrapper for AC_ARG_WITH with default value 'yes'.
+dnl If --with-$1 is given explicitly, set with_$1_requested to given value.
+AC_DEFUN([ARIA2_ARG_WITHOUT],
+[AC_ARG_WITH([$1],
+	AS_HELP_STRING([--without-$1], [Do not use $1. [default=check]]),
 	[with_$1_requested=$withval with_$1=$withval], [with_$1=yes])]
 )
 
 dnl ARIA2_ARG_ENABLE(FEATURE)
-dnl wrapper for AC_ARG_ENABLE with default value 'yes'.
+dnl wrapper for AC_ARG_ENABLE with default value 'no'.
 dnl If --enable-$1 is given explicitly, set enable_$1_requested to given value.
 AC_DEFUN([ARIA2_ARG_ENABLE],
 [AC_ARG_ENABLE([$1],
 	AS_HELP_STRING([--enable-$1], [Enable $1 support.]),
+	[enable_$1_requested=$enableval enable_$1=$enableval], [enable_$1=no])]
+)
+dnl ARIA2_ARG_DISABLE(FEATURE)
+dnl wrapper for AC_ARG_ENABLE with default value 'yes'.
+dnl If --enable-$1 is given explicitly, set enable_$1_requested to given value.
+AC_DEFUN([ARIA2_ARG_DISABLE],
+[AC_ARG_ENABLE([$1],
+  AS_HELP_STRING([--disable-$1], [Disable $1 support. [default=check]]),
 	[enable_$1_requested=$enableval enable_$1=$enableval], [enable_$1=yes])]
 )
 


### PR DESCRIPTION
Most other software uses --disable/--without for features it does build
or at least check by default.

Change aria2 configure options so that:
- --enable-*: do not build by default, unless --enable specified
- --disable-*: check and build by default, unless --disable specified
- --with-*: do not use by default, unless --with specified
- --without-*: check and use by default, unless without specified
