### PR TITLE
AppleTLS: Fixup checkDirection() to return WANT_READ by default

### DIFF
--- a/src/AppleTLSSession.cc
+++ b/src/AppleTLSSession.cc
@@ -366,17 +366,22 @@ int AppleTLSSession::closeConnection()
 }
 
 int AppleTLSSession::checkDirection() {
-  if (writeBuffered_) {
-    return TLS_WANT_WRITE;
-  }
+  // See: https://github.com/tatsuhiro-t/aria2/pull/61#issuecomment-16051793
   if (state_ == st_connected) {
+    // Need to check read first, as SocketCore kinda expects this
     size_t buffered;
     lastError_ = SSLGetBufferedReadSize(sslCtx_, &buffered);
     if (lastError_ == noErr && buffered) {
       return TLS_WANT_READ;
     }
   }
-  return 0;
+
+  if (writeBuffered_) {
+    return TLS_WANT_WRITE;
+  }
+
+  // Default to WANT_READ, as SocketCore kinda expects this
+  return TLS_WANT_READ;
 }
 
 ssize_t AppleTLSSession::writeData(const void* data, size_t len)


### PR DESCRIPTION
As discussed in issue #61.
The log is a lot shorter now :D
