### PR TITLE
Close GZipFiles in the d'tor

### DIFF
--- a/src/GZipFile.cc
+++ b/src/GZipFile.cc
@@ -77,6 +77,7 @@ GZipFile::GZipFile(const char* filename, const char* mode)
 
 GZipFile::~GZipFile()
 {
+  close();
   free(buf_);
 }
 


### PR DESCRIPTION
Forgot to call close in the d'tor, which becomes apparent when the SessionSerializer fails to save a session (e.g. out of space) and leaks the file handle.
