### PR TITLE
Add configure support for linking tcmalloc_minimal and/or jemalloc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -541,7 +541,6 @@ if test "x$with_tcmalloc" = "xyes"; then
   PKG_CHECK_MODULES([TCMALLOC], [libtcmalloc_minimal], [have_tcmalloc=yes], [have_tcmalloc=no])
   if test "x$have_tcmalloc" = "xyes"; then
     CPPFLAGS="$TCMALLOC_CFLAGS $CPPFLAGS"
-    LDFLAGS="$TCMALLOC_LDFLAGS $CPPFLAGS"
     LIBS="$LIBS $TCMALLOC_LIBS"
   else
     AC_CHECK_LIB([tcmalloc_minimal], [malloc], [have_tcmalloc=yes], [have_tcmalloc=no])
@@ -562,7 +561,6 @@ if test "x$have_tcmalloc" != "xyes" && test "x$with_jemalloc" = "xyes"; then
   PKG_CHECK_MODULES([JEMALLOC], [jemalloc], [have_jemalloc=yes], [have_jemalloc=no])
   if test "x$have_jemalloc" = "xyes"; then
     CPPFLAGS="$JEMALLOC_CFLAGS $CPPFLAGS"
-    LDFLAGS="$JEMALLOC_LDFLAGS $CPPFLAGS"
     LIBS="$LIBS $JEMALLOC_LIBS"
   else
     AC_CHECK_LIB([jemalloc], [malloc], [have_jemalloc=yes], [have_jemalloc=no])


### PR DESCRIPTION
Both tcmalloc_minimal and jemalloc outperform the native malloc
implemention on Windows (MSVCRT) in terms of committed memory
consumption (~-30%) and performance (e.g. far less page faults, ~-60%),
depending, of course, on the actual workload.
The longer the download queue, the bigger the impact ;)

On *nix the picture is a little different... tcmalloc usually still
outperforms the native malloc implementation, but not that significantly
than on Windows. jemalloc however is only marginally better than recent
native Linux implementations, while it is already used by some BSD as the
native allocator.

tcmalloc is part of gperftools and very mature and tested by now. It
doesn't work on OSX in the default configuration, however.
http://code.google.com/p/gperftools/

jemalloc is the default allocator at least on FreeBSD and NetBSD and
used in Firefox.
http://www.canonware.com/jemalloc/index.html
