### PR TITLE
Fix invalid reference return in IndexedListIterator

### DIFF
--- a/src/IndexedList.h
+++ b/src/IndexedList.h
@@ -103,7 +103,7 @@ struct IndexedListIterator {
     return *this;
   }
 
-  SelfType& operator--(int)
+  SelfType operator--(int)
   {
     SelfType copy = *this;
     --*this;


### PR DESCRIPTION
Just stumbled upon this bug. I don't think it has any real significance right now, still it is an incorrect.
