### PR TITLE
Fix a bad std::move in HttpConnection

### DIFF
--- a/src/HttpConnection.cc
+++ b/src/HttpConnection.cc
@@ -123,7 +123,8 @@ void HttpConnection::sendRequest
 void HttpConnection::sendRequest
 (std::unique_ptr<HttpRequest> httpRequest)
 {
-  sendRequest(std::move(httpRequest), httpRequest->createRequest());
+  auto req = httpRequest->createRequest();
+  sendRequest(std::move(httpRequest), req);
 }
 
 void HttpConnection::sendProxyRequest


### PR DESCRIPTION
C++ Standard says that the order of evaluation of arguments is
unspecified. Even if it wasn't, std::move would run first, invalidating
the httpRequest smartptr, so that httpRequest->createRequest() would be
executed on the invalid ptr.
Some compilers might be smart enough to correct this error, clang XCode
Edition surely is not (not should it).
