### PR TITLE
XMLRPC (aria2.getGlobalOption) broken.

### DIFF
--- a/src/HttpServerBodyCommand.cc
+++ b/src/HttpServerBodyCommand.cc
@@ -227,8 +227,8 @@ bool HttpServerBodyCommand::execute()
             return true;
           }
           A2_LOG_INFO(fmt("Executing RPC method %s", req.methodName.c_str()));
-          auto res = rpc::getMethod(req.methodName)
-            ->execute(std::move(req), e_);
+          const auto meth = rpc::getMethod(req.methodName);
+          auto res = meth->execute(std::move(req), e_);
           bool gzip = httpServer_->supportsGZip();
           std::string responseData = rpc::toXml(res, gzip);
           httpServer_->feedResponse(std::move(responseData), "text/xml");


### PR DESCRIPTION
Running master on Debian and Win64.

I have this tiny script that I occasionally use to display/update aria2 configuration via XMLRPC (ignore the changeGlobalOption stuff for now):

``` python
import xmlrpclib
import sys

a = xmlrpclib.ServerProxy("http://localhost:6800/rpc").aria2
try:
  _,k,v = sys.argv
  a.changeGlobalOption({k:v})
except:
  pass
o = sorted(a.getGlobalOption().items(), key=lambda x: x[0])
for k,v in o:
  print k,v

```

Result:
`xmlrpclib.Fault: <Fault 1: 'No such method: aria2.getGlobalOption'`

I think jsonrpc does work with the same Debian build.
