### PR TITLE
Figure out the internal ./intl

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS =  po intl lib deps src doc test
+SUBDIRS =  po lib deps src doc test
 
 ACLOCAL_AMFLAGS = -I m4 --install
 RST2HTML = @RST2HTML@

--- a/configure.ac
+++ b/configure.ac
@@ -596,7 +596,7 @@ AC_C_BIGENDIAN
 AC_SYS_LARGEFILE
 
 # Checks for library functions.
-AM_GNU_GETTEXT
+AM_GNU_GETTEXT([external])
 AM_GNU_GETTEXT_VERSION([0.18])
 AC_FUNC_ERROR_AT_LINE
 AC_PROG_GCC_TRADITIONAL
@@ -896,7 +896,6 @@ AC_CONFIG_FILES([Makefile
 		src/includes/Makefile
 		test/Makefile
 		po/Makefile.in
-		intl/Makefile
 		lib/Makefile
 		doc/Makefile
 		doc/manual-src/Makefile


### PR DESCRIPTION
Right now, gettext is configured to use an internal `intl`, which is all nice and dandy, if you get a tarball that actually contains the library.
Otherwise, you may need to run `gettextize --intl` yourself, which, to add insult to injury, is actually  deprecated. `autoreconf` will just invoke `autopoint`, which does not necessarily add `./intl`.
This makes it unnecessarily hard for new folk to modify and/or contribute.

Possible solutions:
- Just commit `./intl`
- Remove support for internal gettext by using `AM_GNU_GETTEXT([external])`  and remove remaining `./intl`stuff from configure.ac and Makefile.am.
- Leave as is, but document `gettextize --intl`.
