### PR TITLE
Fix static builds on darwin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -963,9 +963,14 @@ if test "x$ARIA2_STATIC" = "xyes"; then
   # libtool.
   LDFLAGS="$LDFLAGS -all-static"
   dnl For non-MinGW build, we need additional libs for static build.
-  if test "x$win_build" != "xyes"; then
-    LIBS="$LIBS -lpthread -ldl -lrt"
-  fi
+  case "$host" in
+    *mingw*|*msvc*|*darwin*)
+    ;;
+
+    *)
+      LIBS="$LIBS -lpthread -ldl -lrt"
+    ;;
+  esac
 fi
 
 if test "x$win_build" = "xyes" && test "x$enable_libaria2" = "xyes"; then


### PR DESCRIPTION
While investigating on how to provide easy-to-use static builds on darwin, I found out that ARIA2_STATIC=yes is broken on OSX...
