### PR TITLE
Added support for RPC channel encryption in aria2rpc

### DIFF
--- a/doc/xmlrpc/aria2rpc
+++ b/doc/xmlrpc/aria2rpc
@@ -238,6 +238,8 @@ OptionParser.new do |opt|
 
   opt.on("--user USERNAME", "XML-RPC username"){|val| options["user"]=val }
   opt.on("--passwd PASSWORD", "XML-RPC password"){|val| options["passwd"]=val }
+  opt.on("--secure [BOOL]",["true","false"]){|val| options["secure"]=val||"true" }
+  opt.on("--check-rpc-cert [BOOL]",["true","false"]){|val| options["check-rpc-cert"]=val||"true" }
 
   opt.on("--secret SECRET", "XML-RPC secret authorization token"){|val| options["secret"]=val }
 
@@ -303,19 +305,32 @@ end
 if not options.has_key?("port") then
   options["port"]="6800"
 end
+if not options.has_key?("secure") then
+  options["secure"]="false"
+end
+if not options.has_key?("check-rpc-cert") then
+  options["check-rpc-cert"]="true"
+end
 secret = if options.has_key?("secret") then "token:"+options["secret"] else nil end
 
 client=XMLRPC::Client.new3({:host => options["server"],
                              :port => options["port"],
                              :path => "/rpc",
                              :user => options["user"],
-                             :password => options["passwd"]})
+                             :password => options["passwd"],
+                             :use_ssl => options["secure"]})
+
+if options["check-rpc-cert"] == "false" then
+  client.instance_variable_get(:@http).instance_variable_set(:@verify_mode, OpenSSL::SSL::VERIFY_NONE)
+end
 
 options.delete("server")
 options.delete("port")
 options.delete("user")
 options.delete("passwd")
 options.delete("secret")
+options.delete("secure")
+options.delete("check-rpc-cert")
 
 def client_call client, secret, method, *params
   if secret.nil?


### PR DESCRIPTION
Hi.

I wanted to use aria2rpc to connect to my aria2 server, but noticed I couldn't because aria2rpc doesn't support encryption. I added some code to support this and I thought I could share it. I'll appreciate any feedback.
