### PR TITLE
Remove spurious CXX11_OVERRIDE to make cov-build happy.

### DIFF
--- a/src/ValueBase.h
+++ b/src/ValueBase.h
@@ -322,7 +322,7 @@ class DowncastValueBaseVisitor:public EmptyDowncastValueBaseVisitor {
 public:
   DowncastValueBaseVisitor() : result_{nullptr} {}
 
-  virtual void visit(const T& t) CXX11_OVERRIDE
+  virtual void visit(const T& t)
   {
     result_ = &t;
   }


### PR DESCRIPTION
@tatsuhiro-t In #232 you mention that cov-build does not produce the necessary coverage required for uploading builds.

When I just tried cov-build, I was able to reproduce. The reason seems to be https://github.com/tatsuhiro-t/aria2/blob/master/src/ValueBase.h#L325 : `virtual void visit(const T& t) CXX11_OVERRIDE`. AFAIK you cannot really use override with templates like this. Since `ValueBase.h` is included in most units one way or the other, this led to abysmal coverage results. 
Removing that `CXX11_OVERRIDE` gave me:
-  Compiling with a `g++-4.7` on Debian x86_64 against GnuTLS after some `cov-configure --compiler g++-4.7 -p gcc` then using `cov-build --dir cov-int make V=1`:

``` sh
379 C/C++ compilation units (100%) are ready for analysis
The cov-build utility completed successfully.
```
- Compiling with a `g++4.8` (brew) on OSX 10.9 x86_64 against AppleTLS after some `cov-configure --compiler g++-4.8 -p gcc` then using `cov-build --dir cov-int make V=1`:

``` sh
380 C/C++ compilation units (99%) are ready for analysis
The cov-build utility completed successfully.
```

The missing units being `AppleTLS*.cc`, because cov-build cannot find the (Framework) `<Security/Security.h>` header for whatever reason.

As a non-admin for the aria2 project, I cannot post builds.
(Also, I cannot currently see Defects for aria2 in Coverity ATM, but they seem to have had problems with their infrastructure all day long, so right now I'm waiting to see if this clears up by itself or if I have to contact their support). 
