### PR TITLE
Improve compiler/platform/libs information in logs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -35,6 +35,8 @@ case "$host" in
     ;;
 esac
 
+AC_DEFINE_UNQUOTED([BUILD], ["$build"], [Define build-type])
+AC_DEFINE_UNQUOTED([HOST], ["$host"], [Define build-type])
 AC_DEFINE_UNQUOTED([TARGET], ["$target"], [Define target-type])
 
 # Checks for arguments.
@@ -654,6 +656,7 @@ AC_CHECK_HEADERS([argz.h \
                   sys/time.h \
                   sys/types.h \
                   sys/uio.h \
+                  sys/utsname.h \
                   termios.h \
                   unistd.h \
                   utime.h \

--- a/src/Context.cc
+++ b/src/Context.cc
@@ -174,7 +174,10 @@ Context::Context(bool standalone,
   A2_LOG_INFO("<<--- --- --- ---");
   A2_LOG_INFO("  --- --- --- ---");
   A2_LOG_INFO("  --- --- --- --->>");
-  A2_LOG_INFO(fmt("%s %s %s", PACKAGE, PACKAGE_VERSION, TARGET));
+  A2_LOG_INFO(fmt("%s %s", PACKAGE, PACKAGE_VERSION));
+  A2_LOG_INFO(usedCompilerAndPlatform());
+  A2_LOG_INFO(getOperatingSystemInfo());
+  A2_LOG_INFO(usedLibs());
   A2_LOG_INFO(MSG_LOGGING_STARTED);
 
   if(op->getAsBool(PREF_DISABLE_IPV6)) {

--- a/src/FeatureConfig.h
+++ b/src/FeatureConfig.h
@@ -67,6 +67,12 @@ const char* strSupportedFeature(int feature);
 // aria2.
 std::string usedLibs();
 
+// Returns a summary string of the used compiler/platform.
+std::string usedCompilerAndPlatform();
+
+// Returns the system information about the OS this binary is running on.
+std::string getOperatingSystemInfo();
+
 } // namespace aria2
 
 #endif // D_FEATURE_CONFIG_H

--- a/src/version_usage.cc
+++ b/src/version_usage.cc
@@ -72,6 +72,10 @@ void showVersion() {
             << MessageDigest::getSupportedHashTypeString() << "\n"
             << _("Libraries") << ": "
             << usedLibs() << "\n"
+            << _("Compiler") << ": "
+            << usedCompilerAndPlatform() << "\n"
+            << _("System") << ": "
+            << getOperatingSystemInfo() << "\n"
             << "\n"
             << fmt(_("Report bugs to %s"), PACKAGE_BUGREPORT) << "\n"
             << _("Visit") << " " << PACKAGE_URL << std::endl;


### PR DESCRIPTION
Add and use usedCompilerAndPlatform().  This adds compiler information to
INFO logs and the --version output, and may be helpful when trying to
diagnose/reproduce user-reported problems.

Also make INFO logs include usedLibs() output.
