### PR TITLE
Support round-robin DNS

### DIFF
--- a/src/AbstractCommand.cc
+++ b/src/AbstractCommand.cc
@@ -770,7 +770,7 @@ std::string AbstractCommand::resolveHostname(std::vector<std::string>& addrs,
 
   e_->findAllCachedIPAddresses(std::back_inserter(addrs), hostname, port);
   if (!addrs.empty()) {
-    auto ipaddr = addrs.front();
+    auto ipaddr = addrs[rand() % addrs.size()];
     A2_LOG_INFO(fmt(MSG_DNS_CACHE_HIT,
                     getCuid(),
                     hostname.c_str(),


### PR DESCRIPTION
Currently when DNS returns multiple IP addresses, Aria2 caches them and always connects to the first one even when downloading in parallel. The proposed change makes it connect to different servers, distributing the load. (Rotating servers instead of randomizing them would be a more intelligent option.)
