### PR TITLE
Fixed segfault for unsupported encodings

### DIFF
--- a/src/HttpResponseCommand.cc
+++ b/src/HttpResponseCommand.cc
@@ -115,10 +115,11 @@ std::unique_ptr<StreamFilter> getContentEncodingStreamFilter
                       "process is skipped and the downloaded content will be "
                       "still encoded.",
                       httpResponse->getContentEncoding().c_str()));
+    } else {
+      filter->init();
+      filter->installDelegate(std::move(delegate));
+      return filter;
     }
-    filter->init();
-    filter->installDelegate(std::move(delegate));
-    return filter;
   }
   return delegate;
 }


### PR DESCRIPTION
After failing a null check filter is being used anyway causing a segmentation fault. This seems to fix the issue.
