### PR TITLE
Work around libintl's vprintf macro messing with OutputFile::vprintf

### DIFF
--- a/src/OutputFile.h
+++ b/src/OutputFile.h
@@ -40,6 +40,9 @@
 #include <cstdlib>
 #include <cstdarg>
 
+// include <string> just to cancel libintl's #define vprintf libintl_vprintf
+#include <string>
+
 namespace aria2 {
 
 class OutputFile {


### PR DESCRIPTION
This solved the errors mentioned in #286.
