### PR TITLE
Update README URLs based on HTTP redirects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -183,7 +183,7 @@ script respectively.
 
 In order to enable async DNS support, you need c-ares.
 
-* c-ares: http://daniel.haxx.se/projects/c-ares/
+* c-ares: http://c-ares.haxx.se/
 
 How to build
 ------------
@@ -307,7 +307,7 @@ Cross-compiling Windows binary
 ------------------------------
 
 In this section, we describe how to build a Windows binary using a
-mingw-w64 (http://mingw-w64.sourceforge.net/) cross-compiler on Debian
+mingw-w64 (http://mingw-w64.org/doku.php) cross-compiler on Debian
 Linux. The MinGW (http://www.mingw.org/) may not be able to build
 aria2.
 
@@ -584,4 +584,4 @@ References
 * `BitTorrent: Private Torrents <http://www.bittorrent.org/beps/bep_0027.html>`_
 * `BitTorrent: BitTorrent DHT Extensions for IPv6 <http://www.bittorrent.org/beps/bep_0032.html>`_
 * `BitTorrent: Message Stream Encryption <http://wiki.vuze.com/w/Message_Stream_Encryption>`_
-* `Kademlia: A Peer-to-peer Information System Based on the  XOR Metric <http://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf>`_
+* `Kademlia: A Peer-to-peer Information System Based on the  XOR Metric <https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf>`_


### PR DESCRIPTION
Created with https://github.com/dkhamsing/frankenstein

### HTTPS Corrected URLs 
Was | Now 
--- | --- 
http://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf | https://pdos.csail.mit.edu/~petar/papers/maymounkov-kademlia-lncs.pdf 


### Other Corrected URLs 
Was | Now 
--- | --- 
http://daniel.haxx.se/projects/c-ares/ | http://c-ares.haxx.se/ 
http://mingw-w64.sourceforge.net/ | http://mingw-w64.org/doku.php 
