### PR TITLE
Allow --max-connection-per-server to go up to 128.

### DIFF
--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -419,7 +419,7 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
   {
     OptionHandler* op(new NumberOptionHandler(PREF_MAX_CONNECTION_PER_SERVER,
                                               TEXT_MAX_CONNECTION_PER_SERVER,
-                                              "1", 1, 16, 'x'));
+                                              "1", 1, 128, 'x'));
     op->addTag(TAG_BASIC);
     op->addTag(TAG_FTP);
     op->addTag(TAG_HTTP);


### PR DESCRIPTION
Some ISPs seem to limit the maximum bitrate per TCP session through some
routes. Greatly increasing the number of connections to a remote server
allows user to bypass these artificial limitations.