### PR TITLE
added filesize overflow check for mmap on 32bit os

### DIFF
--- a/src/AbstractDiskWriter.cc
+++ b/src/AbstractDiskWriter.cc
@@ -373,6 +373,14 @@ void AbstractDiskWriter::ensureMmapWrite(size_t len, int64_t offset)
         return;
       }
 
+      uint32_t filesize_lo = filesize & 0xffffffffu;
+      if (sizeof(off_t) > sizeof(size_t) && (filesize_lo) > 0) {
+        // filesize could overflow in 32bit OS with 64bit off_t type
+        // the filesize will be truncated if provided as a 32bit size_t
+        enableMmap_ = false;
+        return;
+      }
+
       int errNum = 0;
       if (static_cast<int64_t>(len + offset) <= filesize) {
 #ifdef __MINGW32__

--- a/src/AbstractDiskWriter.cc
+++ b/src/AbstractDiskWriter.cc
@@ -398,10 +398,14 @@ void AbstractDiskWriter::ensureMmapWrite(size_t len, int64_t offset)
           errNum = GetLastError();
         }
 #else  // !__MINGW32__
-        mapaddr_ = reinterpret_cast<unsigned char*>(mmap(
-            nullptr, filesize, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0));
-        if (!mapaddr_) {
+        void * pa = mmap(nullptr, filesize, PROT_READ | PROT_WRITE, MAP_SHARED, fd_, 0);
+
+        if (pa == MAP_FAILED) {
           errNum = errno;
+          mapaddr_ = nullptr;
+        }
+        else {
+          mapaddr_ = reinterpret_cast<unsigned char*>(pa);
         }
 #endif // !__MINGW32__
         if (mapaddr_) {

--- a/src/AbstractDiskWriter.cc
+++ b/src/AbstractDiskWriter.cc
@@ -373,8 +373,7 @@ void AbstractDiskWriter::ensureMmapWrite(size_t len, int64_t offset)
         return;
       }
 
-      uint32_t filesize_lo = filesize & 0xffffffffu;
-      if (sizeof(off_t) > sizeof(size_t) && (filesize_lo) > 0) {
+      if (static_cast<uint64_t>(std::numeric_limits<size_t>::max()) < static_cast<uint64_t>(filesize)) {
         // filesize could overflow in 32bit OS with 64bit off_t type
         // the filesize will be truncated if provided as a 32bit size_t
         enableMmap_ = false;


### PR DESCRIPTION
This has been causing problems with my 32-bit ARMv7L machine. 

It seems like aria2 is compiled with 64-bit offset support so the `filesize` (`st_size` of [`stat`](http://linux.die.net/man/2/stat)) would be a 64-bit `off_t`, even in a 32-bit O/S. 

The problem is, `length` arg in [`mmap`](http://linux.die.net/man/2/mmap) is a 32-bit `size_t` in 32-bit O/S, so the input, `filesize`, would be truncated and the mmap would not be mapping into a correct size of address space.

This will cause `SIGSEGV` in later `memcpy` operations.