### PR TITLE
allow seconds for seed-time (fractional minutes)

### DIFF
--- a/src/BtSetup.cc
+++ b/src/BtSetup.cc
@@ -158,7 +158,7 @@ void BtSetup::setup(std::vector<std::unique_ptr<Command>>& commands,
     auto unionCri = make_unique<UnionSeedCriteria>();
     if (option->defined(PREF_SEED_TIME)) {
       unionCri->addSeedCriteria(make_unique<TimeSeedCriteria>(
-          std::chrono::seconds(option->getAsInt(PREF_SEED_TIME) * 60)));
+          std::chrono::seconds((int)(option->getAsDouble(PREF_SEED_TIME) * 60))));
     }
     {
       double ratio = option->getAsDouble(PREF_SEED_RATIO);

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1799,7 +1799,7 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
   {
-    OptionHandler* op(new NumberOptionHandler(PREF_SEED_TIME, TEXT_SEED_TIME,
+    OptionHandler* op(new FloatNumberOptionHandler(PREF_SEED_TIME, TEXT_SEED_TIME,
                                               NO_DEFAULT_VALUE, 0));
     op->addTag(TAG_BITTORRENT);
     op->setInitialOption(true);

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -420,7 +420,7 @@ extern PrefPtr PREF_LISTEN_PORT;
 extern PrefPtr PREF_FOLLOW_TORRENT;
 // values: 1*digit *( (,|-) 1*digit)
 extern PrefPtr PREF_SELECT_FILE;
-// values: 1*digit
+// values: 1*digit ['.' [ 1*digit ] ]
 extern PrefPtr PREF_SEED_TIME;
 // values: 1*digit ['.' [ 1*digit ] ]
 extern PrefPtr PREF_SEED_RATIO;

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -313,7 +313,7 @@
     "                              To limit the overall upload speed, use\n" \
     "                              --max-overall-upload-limit option.")
 #define TEXT_SEED_TIME                                                  \
-  _(" --seed-time=MINUTES          Specify seeding time in minutes. Also see the\n" \
+  _(" --seed-time=MINUTES          Specify seeding time in (fractional) minutes. Also see the\n" \
     "                              --seed-ratio option.")
 #define TEXT_SEED_RATIO                                                 \
   _(" --seed-ratio=RATIO           Specify share ratio. Seed completed torrents\n" \


### PR DESCRIPTION
This allows aria2 to stay up for seeding during seconds and not only full minutes. This is interesting on high speed networks with large number of clients who actually need the file quickly but still want to participate in case all servers need the same file at almost the same time.