### PR TITLE
Better auto-renaming

### DIFF
--- a/src/RequestGroup.cc
+++ b/src/RequestGroup.cc
@@ -778,8 +778,16 @@ void RequestGroup::tryAutoFileRenaming()
         fmt("File renaming failed: %s", getFirstFilePath().c_str()),
         error_code::FILE_RENAMING_FAILED);
   }
+  auto fn = filepath;
+  std::string ext;
+  auto idx = fn.find_last_of(".");
+  auto slash = fn.find_last_of("\\/");
+  if (idx != std::string::npos && (slash == std::string::npos || slash < idx)) {
+    ext = fn.substr(idx);
+    fn = fn.substr(0, idx);
+  }
   for (int i = 1; i < 10000; ++i) {
-    auto newfilename = fmt("%s.%d", filepath.c_str(), i);
+    auto newfilename = fmt("%s.%d%s", fn.c_str(), i, ext.c_str());
     File newfile(newfilename);
     File ctrlfile(newfile.getPath() + DefaultBtProgressInfoFile::getSuffix());
     if (!newfile.exists() || (newfile.exists() && ctrlfile.exists())) {

--- a/src/RequestGroup.cc
+++ b/src/RequestGroup.cc
@@ -780,9 +780,21 @@ void RequestGroup::tryAutoFileRenaming()
   }
   auto fn = filepath;
   std::string ext;
-  auto idx = fn.find_last_of(".");
-  auto slash = fn.find_last_of("\\/");
-  if (idx != std::string::npos && (slash == std::string::npos || slash < idx)) {
+  const auto idx = fn.find_last_of(".");
+  const auto slash = fn.find_last_of("\\/");
+  // Do extract the extension, as in "file.ext" = "file" and ".ext",
+  // but do not consider ".file" to be a file name without extension instead
+  // of a blank file name and an extension of ".file"
+  if (idx != std::string::npos &&
+      // fn has no path component and starts with a dot, but has no extension
+      // otherwise
+      idx != 0 &&
+      // has a file path component if we found a slash.
+      // if slash == idx - 1 this means a form of "*/.*", so the file name
+      // starts with a dot, has no extension otherwise, and therefore do not
+      // extract an extension either
+      (slash == std::string::npos || slash < idx - 1)
+      ) {
     ext = fn.substr(idx);
     fn = fn.substr(0, idx);
   }

--- a/src/RequestGroup.h
+++ b/src/RequestGroup.h
@@ -199,8 +199,6 @@ private:
 
   void initializePostDownloadHandler();
 
-  void tryAutoFileRenaming();
-
   // Returns the result code of this RequestGroup.  If the download
   // finished, then returns error_code::FINISHED.  If the
   // download didn't finish and error result is available in
@@ -218,6 +216,8 @@ public:
   ~RequestGroup();
 
   bool isCheckIntegrityReady();
+
+  void tryAutoFileRenaming();
 
   const std::shared_ptr<SegmentMan>& getSegmentMan() const
   {

--- a/test/RequestGroupTest.cc
+++ b/test/RequestGroupTest.cc
@@ -39,6 +39,35 @@ void RequestGroupTest::testGetFirstFilePath()
 
   CPPUNIT_ASSERT_EQUAL(std::string("/tmp/myfile"), group.getFirstFilePath());
 
+  // test file renaming
+  option_->put(PREF_AUTO_FILE_RENAMING, "false");
+  try {
+    group.tryAutoFileRenaming();
+  }
+  catch (const Exception& ex) {
+    CPPUNIT_ASSERT_EQUAL(error_code::FILE_ALREADY_EXISTS, ex.getErrorCode());
+
+  }
+
+  option_->put(PREF_AUTO_FILE_RENAMING, "true");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp/myfile.1"), group.getFirstFilePath());
+
+  ctx->getFirstFileEntry()->setPath("/tmp/myfile.txt");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp/myfile.1.txt"), group.getFirstFilePath());
+
+  ctx->getFirstFileEntry()->setPath("/tmp.txt/myfile");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp.txt/myfile.1"), group.getFirstFilePath());
+
+  ctx->getFirstFileEntry()->setPath("/tmp.txt/myfile.txt");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp.txt/myfile.1.txt"), group.getFirstFilePath());
+
+  // test in-memory
+  ctx->getFirstFileEntry()->setPath("/tmp/myfile");
+
   group.markInMemoryDownload();
 
   CPPUNIT_ASSERT_EQUAL(std::string("[MEMORY]myfile"), group.getFirstFilePath());

--- a/test/RequestGroupTest.cc
+++ b/test/RequestGroupTest.cc
@@ -14,6 +14,7 @@ class RequestGroupTest : public CppUnit::TestFixture {
 
   CPPUNIT_TEST_SUITE(RequestGroupTest);
   CPPUNIT_TEST(testGetFirstFilePath);
+  CPPUNIT_TEST(testTryAutoFileRenaming);
   CPPUNIT_TEST(testCreateDownloadResult);
   CPPUNIT_TEST_SUITE_END();
 
@@ -24,6 +25,7 @@ public:
   void setUp() { option_.reset(new Option()); }
 
   void testGetFirstFilePath();
+  void testTryAutoFileRenaming();
   void testCreateDownloadResult();
 };
 
@@ -39,7 +41,22 @@ void RequestGroupTest::testGetFirstFilePath()
 
   CPPUNIT_ASSERT_EQUAL(std::string("/tmp/myfile"), group.getFirstFilePath());
 
-  // test file renaming
+  // test in-memory
+  ctx->getFirstFileEntry()->setPath("/tmp/myfile");
+
+  group.markInMemoryDownload();
+
+  CPPUNIT_ASSERT_EQUAL(std::string("[MEMORY]myfile"), group.getFirstFilePath());
+}
+
+void RequestGroupTest::testTryAutoFileRenaming()
+{
+  std::shared_ptr<DownloadContext> ctx(
+      new DownloadContext(1_k, 1_k, "/tmp/myfile"));
+
+  RequestGroup group(GroupId::create(), option_);
+  group.setDownloadContext(ctx);
+
   option_->put(PREF_AUTO_FILE_RENAMING, "false");
   try {
     group.tryAutoFileRenaming();
@@ -65,12 +82,22 @@ void RequestGroupTest::testGetFirstFilePath()
   group.tryAutoFileRenaming();
   CPPUNIT_ASSERT_EQUAL(std::string("/tmp.txt/myfile.1.txt"), group.getFirstFilePath());
 
-  // test in-memory
-  ctx->getFirstFileEntry()->setPath("/tmp/myfile");
+  ctx->getFirstFileEntry()->setPath(".bashrc");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string(".bashrc.1"), group.getFirstFilePath());
 
-  group.markInMemoryDownload();
+  ctx->getFirstFileEntry()->setPath(".bashrc.txt");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string(".bashrc.1.txt"), group.getFirstFilePath());
 
-  CPPUNIT_ASSERT_EQUAL(std::string("[MEMORY]myfile"), group.getFirstFilePath());
+  ctx->getFirstFileEntry()->setPath("/tmp.txt/.bashrc");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp.txt/.bashrc.1"), group.getFirstFilePath());
+
+  ctx->getFirstFileEntry()->setPath("/tmp.txt/.bashrc.txt");
+  group.tryAutoFileRenaming();
+  CPPUNIT_ASSERT_EQUAL(std::string("/tmp.txt/.bashrc.1.txt"), group.getFirstFilePath());
+
 }
 
 void RequestGroupTest::testCreateDownloadResult()


### PR DESCRIPTION
having things like "image.jpg.1" when autorenaming happens is only marginally helpful... It is better to rename it to "image.1.jpg" instead, which is what this PR does.
If a file has no extension, it will still become just "file.1".

Added tests for this too, which required making `tryAutoFileRenaming` public (short of nasty "only make this public in tests" hacks)