### PR TITLE
 correcting the copyright format error

### DIFF
--- a/src/LpdMessage.cc
+++ b/src/LpdMessage.cc
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #include "LpdMessage.h"
 #include "Peer.h"
 

--- a/src/LpdMessage.h
+++ b/src/LpdMessage.h
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #ifndef D_LPD_MESSAGE_H
 #define D_LPD_MESSAGE_H
 

--- a/src/LpdMessageDispatcher.cc
+++ b/src/LpdMessageDispatcher.cc
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #include "LpdMessageDispatcher.h"
 #include "SocketCore.h"
 #include "A2STR.h"

--- a/src/LpdMessageDispatcher.h
+++ b/src/LpdMessageDispatcher.h
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #ifndef D_LPD_MESSAGE_DISPATCHER_H
 #define D_LPD_MESSAGE_DISPATCHER_H
 

--- a/src/LpdMessageReceiver.cc
+++ b/src/LpdMessageReceiver.cc
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #include "LpdMessageReceiver.h"
 #include "SocketCore.h"
 #include "Logger.h"

--- a/src/LpdMessageReceiver.h
+++ b/src/LpdMessageReceiver.h
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *
@@ -30,6 +31,8 @@
  * version.  If you delete this exception statement from all source
  * files in the program, then also delete it here.
  */
+ /* copyright --> */
+ 
 #ifndef D_LPD_MESSAGE_RECEIVER_H
 #define D_LPD_MESSAGE_RECEIVER_H
 

--- a/src/a2netcompat.h
+++ b/src/a2netcompat.h
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *

--- a/src/a2time.h
+++ b/src/a2time.h
@@ -1,3 +1,4 @@
+/* <!-- copyright */
 /*
  * aria2 - The high speed download utility
  *


### PR DESCRIPTION
  Append some lines in some files, making the copyright annotation in a consistent format.  