### PR TITLE
Bugfix: Unauthorized call in aria2mon

### DIFF
--- a/doc/xmlrpc/aria2mon
+++ b/doc/xmlrpc/aria2mon
@@ -140,7 +140,7 @@ result.each { |entry|
   end
   print "\n"
 
-  files=client.call("aria2.getFiles",entry['gid'])
+  files=client_call(client,"aria2.getFiles",entry['gid'])
   if files.length > 0 then
     first_file=files.find{|file| file["selected"]=="true"}
     if first_file != nil then

--- a/doc/xmlrpc/aria2mon
+++ b/doc/xmlrpc/aria2mon
@@ -140,7 +140,7 @@ result.each { |entry|
   end
   print "\n"
 
-  files=client_call(client,"aria2.getFiles",entry['gid'])
+  files=client_call(client,secret,"aria2.getFiles",entry['gid'])
   if files.length > 0 then
     first_file=files.find{|file| file["selected"]=="true"}
     if first_file != nil then


### PR DESCRIPTION
Hi,

in commit a9fe783484e9196d05b9ea99f441f129365c7034, you already introduced the "secret" parameter to aria2mon. However, in the following call to `aria2.getFiles`, you do not use it, which causes a "Unauthorized (XMLRPC::FaultException)".

Therefore, I replaced the "direct" `client.call` with the local method `client_call` and put the (potential empty) secret as second parameter, so that `clent_call` can either ignore or use it.