### PR TITLE
Use stdin for *NIX as well

### DIFF
--- a/src/BufferedFile.cc
+++ b/src/BufferedFile.cc
@@ -44,15 +44,15 @@
 namespace aria2 {
 
 BufferedFile::BufferedFile(const char* filename, const char* mode)
-    :
-#ifdef __MINGW32__
-      fp_(strcmp(DEV_STDIN, filename) == 0
+    : fp_(strcmp(DEV_STDIN, filename) == 0
               ? stdin
-              : a2fopen(utf8ToWChar(filename).c_str(),
-                        utf8ToWChar(mode).c_str())),
+              :
+#ifdef __MINGW32__
+              a2fopen(utf8ToWChar(filename).c_str(), utf8ToWChar(mode).c_str())
 #else  // !__MINGW32__
-      fp_(a2fopen(filename, mode)),
+              a2fopen(filename, mode)
 #endif // !__MINGW32__
+              ),
       supportsColor_(fp_ ? isatty(fileno(fp_)) : false)
 {
 }

--- a/src/GZipFile.cc
+++ b/src/GZipFile.cc
@@ -46,15 +46,16 @@ namespace aria2 {
 GZipFile::GZipFile(const char* filename, const char* mode)
     : fp_(nullptr), buflen_(1_k), buf_(reinterpret_cast<char*>(malloc(buflen_)))
 {
-  FILE* fp =
-#ifdef __MINGW32__
+  auto fp =
       strcmp(DEV_STDIN, filename) == 0
           ? stdin
-          : a2fopen(utf8ToWChar(filename).c_str(), utf8ToWChar(mode).c_str());
+          :
+#ifdef __MINGW32__
+          a2fopen(utf8ToWChar(filename).c_str(), utf8ToWChar(mode).c_str())
 #else  // !__MINGW32__
-      a2fopen(filename, mode);
+          a2fopen(filename, mode)
 #endif // !__MINGW32__
-
+      ;
   if (fp) {
     int fd = dup(fileno(fp));
     if (fd != -1) {


### PR DESCRIPTION
We thought that we can use /dev/stdin for *NIX, but some variants,
like Android, does not have one or root permission is required.  Just
like we do for Windows build, we just use stdin if /dev/stdin is used.

Fixes #785 