### PR TITLE
Better error message when local file status cannot be retrieved

### DIFF
--- a/src/File.cc
+++ b/src/File.cc
@@ -79,6 +79,16 @@ bool File::exists()
   return fillStat(fstat) == 0;
 }
 
+bool File::exists(std::string &err)
+{
+  a2_struct_stat fstat;
+  if (fillStat(fstat) != 0) {
+    err = fmt("Could not get file status: %s", strerror(errno));
+    return false;
+  }
+  return true;
+}
+
 bool File::isFile()
 {
   a2_struct_stat fstat;

--- a/src/File.h
+++ b/src/File.h
@@ -71,6 +71,13 @@ public:
   bool exists();
 
   /**
+   * Tests whether the file or directory denoted by name exists.  If
+   * file does not exist, or file status could not be retrieved, this
+   * function stores error message to |err|.
+   */
+  bool exists(std::string& err);
+
+  /**
    * Tests whether the file denoted by name is a regular file.
    */
   bool isFile();

--- a/src/OptionHandlerImpl.cc
+++ b/src/OptionHandlerImpl.cc
@@ -551,7 +551,11 @@ void LocalFilePathOptionHandler::parseArg(Option& option,
     auto path = util::replace(optarg, "${HOME}", util::getHomeDir());
     if (mustExist_) {
       File f(path);
-      if (!f.exists() || f.isDir()) {
+      std::string err;
+      if (!f.exists(err)) {
+        throw DL_ABORT_EX(err);
+      }
+      if (f.isDir()) {
         throw DL_ABORT_EX(fmt(MSG_NOT_FILE, optarg.c_str()));
       }
     }


### PR DESCRIPTION
Fixes the misleading error message issue reported in #835.