### PR TITLE
Add --bt-load-saved-metadata option

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -713,6 +713,14 @@ BitTorrent Specific Options
  option to ``false``.  This option has effect only on BitTorrent download.
  Default: ``true``
 
+.. option:: --bt-load-saved-metadata[=true|false]
+
+  Before getting torrent metadata from DHT when downloading with
+  magnet link, first try to read file saved by
+  :option:`--bt-save-metadata` option.  If it is successful, then skip
+  downloading metadata from DHT.
+  Default: ``false``
+
 .. option:: --bt-lpd-interface=<INTERFACE>
 
   Use given interface for Local Peer Discovery. If this option is not
@@ -2111,6 +2119,7 @@ of URIs. These optional lines must start with white space(s).
   * :option:`bt-external-ip <--bt-external-ip>`
   * :option:`bt-force-encryption <--bt-force-encryption>`
   * :option:`bt-hash-check-seed <--bt-hash-check-seed>`
+  * :option:`bt-load-saved-metadata <--bt-load-saved-metadata>`
   * :option:`bt-max-peers <--bt-max-peers>`
   * :option:`bt-metadata-only <--bt-metadata-only>`
   * :option:`bt-min-crypto-level <--bt-min-crypto-level>`

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1528,6 +1528,16 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
   {
+    OptionHandler* op(new BooleanOptionHandler(
+        PREF_BT_LOAD_SAVED_METADATA, TEXT_BT_LOAD_SAVED_METADATA, A2_V_FALSE,
+        OptionHandler::OPT_ARG));
+    op->addTag(TAG_BITTORRENT);
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
+  {
     OptionHandler* op(new DefaultOptionHandler(
         PREF_BT_LPD_INTERFACE, TEXT_BT_LPD_INTERFACE, NO_DEFAULT_VALUE,
         "interface, IP address", OptionHandler::REQ_ARG));

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -563,6 +563,8 @@ PrefPtr PREF_BT_FORCE_ENCRYPTION = makePref("bt-force-encryption");
 // values: true | false
 PrefPtr PREF_BT_ENABLE_HOOK_AFTER_HASH_CHECK =
     makePref("bt-enable-hook-after-hash-check");
+// values: true | false
+PrefPtr PREF_BT_LOAD_SAVED_METADATA = makePref("bt-load-saved-metadata");
 
 /**
  * Metalink related preferences

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -514,6 +514,8 @@ extern PrefPtr PREF_BT_DETACH_SEED_ONLY;
 extern PrefPtr PREF_BT_FORCE_ENCRYPTION;
 // values: true | false
 extern PrefPtr PREF_BT_ENABLE_HOOK_AFTER_HASH_CHECK;
+// values: true | false
+extern PrefPtr PREF_BT_LOAD_SAVED_METADATA;
 
 /**
  * Metalink related preferences

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -1117,4 +1117,12 @@
     "                              number of unfinished download result to keep. If\n" \
     "                              that is undesirable, turn this option off.")
 
+#define TEXT_BT_LOAD_SAVED_METADATA \
+  _(" --bt-load-saved-metadata[=true|false]\n" \
+    "                              Before getting torrent metadata from DHT when\n" \
+    "                              downloading with magnet link, first try to read\n" \
+    "                              file saved by --bt-save-metadata option. If it is\n" \
+    "                              successful, then skip downloading metadata from\n" \
+    "                              DHT.")
+
 // clang-format on


### PR DESCRIPTION
Before getting torrent metadata from DHT when downloading with magnet
link, first try to read file saved by --bt-save-metadata option. If it
is successful, then skip downloading metadata from DHT.  By default,
this feature is turned off.

Fixes #909 