### PR TITLE
[Docs, libaria2] Fix type of obj pushed into options vector

### DIFF
--- a/doc/manual-src/en/libaria2.rst
+++ b/doc/manual-src/en/libaria2.rst
@@ -98,7 +98,7 @@ representing aria2 options. For example, specify an option
 ``file-allocation`` to ``none``::
 
     aria2::KeyVals options;
-    options.push_back(aria2::KeyVals("file-allocation", "none"));
+    options.push_back(std::pair<std::string, std::string> ("file-allocation", "none"));
 
 The first argument of :func:`sessionNew()` is analogous to the
 command-line argument to aria2c program. In the example program, we


### PR DESCRIPTION
aria2::KeyVals is a vector of pair of std strings, therefore the type of object being pushed should be std::pair<std::string, std::string>,
however in the docs, the type of the said object is KeyVals.
If one follows the docs, their code will fail to compile.