### PR TITLE
[WIP] Add option for bt extended handshake version/user agent string

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -954,6 +954,15 @@ BitTorrent Specific Options
   replaced by major, minor and patch version number respectively.  For
   instance, aria2 version 1.18.8 has prefix ID ``A2-1-18-8-``.
 
+.. option:: --peer-agent=<PEER_AGENT>
+
+  Specify the string used during the bitorrent extended handshake
+  for the peer's client version.
+
+  Default: ``aria2/$MAJOR.$MINOR.$PATCH``, $MAJOR, $MINOR and $PATCH are
+  replaced by major, minor and patch version number respectively.  For
+  instance, aria2 version 1.18.8 has peer agent ``aria2/1.18.8``.
+
 .. option:: --seed-ratio=<RATIO>
 
   Specify share ratio. Seed completed torrents until share ratio reaches

--- a/src/Context.cc
+++ b/src/Context.cc
@@ -166,6 +166,7 @@ Context::Context(bool standalone, int argc, char** argv, const KeyVals& options)
   }
 #ifdef ENABLE_BITTORRENT
   bittorrent::generateStaticPeerId(op->get(PREF_PEER_ID_PREFIX));
+  bittorrent::generateStaticPeerAgent(op->get(PREF_PEER_AGENT));
 #endif // ENABLE_BITTORRENT
   LogFactory::setLogFile(op->get(PREF_LOG));
   LogFactory::setLogLevel(op->get(PREF_LOG_LEVEL));

--- a/src/DefaultBtInteractive.cc
+++ b/src/DefaultBtInteractive.cc
@@ -199,7 +199,7 @@ void DefaultBtInteractive::addPortMessageToQueue()
 void DefaultBtInteractive::addHandshakeExtendedMessageToQueue()
 {
   auto m = make_unique<HandshakeExtensionMessage>();
-  m->setClientVersion("aria2/" PACKAGE_VERSION);
+  m->setClientVersion(bittorrent::getStaticPeerAgent());
   m->setTCPPort(tcpPort_);
   m->setExtensions(extensionMessageRegistry_->getExtensions());
   auto attrs = bittorrent::getTorrentAttrs(downloadContext_);

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1854,6 +1854,12 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
   {
+    OptionHandler* op(new DefaultOptionHandler(
+        PREF_PEER_AGENT, TEXT_PEER_AGENT, "aria2/" PACKAGE_VERSION));
+    op->addTag(TAG_BITTORRENT);
+    handlers.push_back(op);
+  }
+  {
     OptionHandler* op(new FloatNumberOptionHandler(
         PREF_SEED_TIME, TEXT_SEED_TIME, NO_DEFAULT_VALUE, 0));
     op->addTag(TAG_BITTORRENT);

--- a/src/bittorrent_helper.cc
+++ b/src/bittorrent_helper.cc
@@ -88,6 +88,7 @@ const char C_COMMENT_UTF8[] = "comment.utf-8";
 const char C_CREATED_BY[] = "created by";
 
 const char DEFAULT_PEER_ID_PREFIX[] = "aria2-";
+const char DEFAULT_PEER_AGENT[] = "aria2/" PACKAGE_VERSION;
 } // namespace
 
 const std::string MULTI("multi");
@@ -693,6 +694,7 @@ std::string generatePeerId(const std::string& peerIdPrefix)
 
 namespace {
 std::string peerId;
+std::string peerAgent;
 } // namespace
 
 const std::string& generateStaticPeerId(const std::string& peerIdPrefix)
@@ -703,7 +705,16 @@ const std::string& generateStaticPeerId(const std::string& peerIdPrefix)
   return peerId;
 }
 
+const std::string& generateStaticPeerAgent(const std::string& peerAgentNew)
+{
+  if (peerAgent.empty()) {
+    peerAgent = peerAgentNew;
+  }
+  return peerAgent;
+}
+
 void setStaticPeerId(const std::string& newPeerId) { peerId = newPeerId; }
+void setStaticPeerAgent(const std::string& newPeerAgent) { peerAgent = newPeerAgent; }
 
 // If PeerID is not generated, it is created with default peerIdPrefix
 // (aria2-).
@@ -716,6 +727,16 @@ const unsigned char* getStaticPeerId()
   else {
     return reinterpret_cast<const unsigned char*>(peerId.data());
   }
+}
+
+// If PeerAgent is not generated, it is created with default agent
+// aria2/PACKAGE_VERSION
+const std::string& getStaticPeerAgent()
+{
+  if (peerAgent.empty()) {
+    generateStaticPeerAgent(DEFAULT_PEER_AGENT);
+  }
+  return peerAgent;
 }
 
 uint8_t getId(const unsigned char* msg) { return msg[0]; }

--- a/src/bittorrent_helper.h
+++ b/src/bittorrent_helper.h
@@ -134,14 +134,20 @@ std::string generatePeerId(const std::string& peerIdPrefix);
 // uses generatePeerId(peerIdPrefix) to produce Peer ID.
 const std::string& generateStaticPeerId(const std::string& peerIdPrefix);
 
+const std::string& generateStaticPeerAgent(const std::string& peerAgent);
+
 // Returns Peer ID statically stored by generateStaticPeerId().  If
 // Peer ID is not stored yet, this function calls
 // generateStaticPeerId("aria2-")
 const unsigned char* getStaticPeerId();
 
+const std::string& getStaticPeerAgent();
+
 // Set newPeerId as a static Peer ID. newPeerId must be 20-byte
 // length.
 void setStaticPeerId(const std::string& newPeerId);
+
+void setStaticPeerAgent(const std::string& newPeerAgent);
 
 // Computes fast set index and returns them.
 std::vector<size_t> computeFastSet(const std::string& ipaddr, size_t numPieces,

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -482,6 +482,8 @@ PrefPtr PREF_SEED_RATIO = makePref("seed-ratio");
 PrefPtr PREF_BT_KEEP_ALIVE_INTERVAL = makePref("bt-keep-alive-interval");
 // values: a string, less than or equals to 20 bytes length
 PrefPtr PREF_PEER_ID_PREFIX = makePref("peer-id-prefix");
+// values: a string representing the extended BT handshake peer user agent
+PrefPtr PREF_PEER_AGENT = makePref("peer-agent");
 // values: true | false
 PrefPtr PREF_ENABLE_PEER_EXCHANGE = makePref("enable-peer-exchange");
 // values: true | false

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -434,6 +434,8 @@ extern PrefPtr PREF_SEED_RATIO;
 extern PrefPtr PREF_BT_KEEP_ALIVE_INTERVAL;
 // values: a string, less than or equals to 20 bytes length
 extern PrefPtr PREF_PEER_ID_PREFIX;
+// values: a string representing the extended BT handshake peer user agent
+extern PrefPtr PREF_PEER_AGENT;
 // values: true | false
 extern PrefPtr PREF_ENABLE_PEER_EXCHANGE;
 // values: true | false

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -331,6 +331,8 @@
     "                              bytes are specified, only first 20 bytes are\n" \
     "                              used. If less than 20 bytes are specified, random\n" \
     "                              byte data are added to make its length 20 bytes.")
+#define TEXT_PEER_AGENT                                                 \
+  _(" --peer-agent=PEER_AGENT  Set client reported during Extended torrent handshakes")
 #define TEXT_ENABLE_PEER_EXCHANGE                                       \
   _(" --enable-peer-exchange[=true|false] Enable Peer Exchange extension.")
 #define TEXT_ENABLE_DHT                                         \

--- a/test/BittorrentHelperTest.cc
+++ b/test/BittorrentHelperTest.cc
@@ -42,6 +42,7 @@ class BittorrentHelperTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testGetPieceLength);
   CPPUNIT_TEST(testGetInfoHashAsString);
   CPPUNIT_TEST(testGetPeerId);
+  CPPUNIT_TEST(testGetPeerAgent);
   CPPUNIT_TEST(testComputeFastSet);
   CPPUNIT_TEST(testGetFileEntries_multiFileUrlList);
   CPPUNIT_TEST(testGetFileEntries_singleFileUrlList);
@@ -100,6 +101,7 @@ public:
   void testGetPieceLength();
   void testGetInfoHashAsString();
   void testGetPeerId();
+  void testGetPeerAgent();
   void testComputeFastSet();
   void testGetFileEntries_multiFileUrlList();
   void testGetFileEntries_singleFileUrlList();
@@ -323,6 +325,13 @@ void BittorrentHelperTest::testGetPeerId()
   std::string peerId = generatePeerId("aria2-");
   CPPUNIT_ASSERT(peerId.find("aria2-") == 0);
   CPPUNIT_ASSERT_EQUAL((size_t)20, peerId.size());
+}
+
+void BittorrentHelperTest::testGetPeerAgent()
+{
+  std::string peerAgent = generateStaticPeerAgent("aria2/-1.-1.-1");
+  CPPUNIT_ASSERT_EQUAL(std::string("aria2/-1.-1.-1"), peerAgent);
+  CPPUNIT_ASSERT_EQUAL(std::string("aria2/-1.-1.-1"), bittorrent::getStaticPeerAgent());
 }
 
 void BittorrentHelperTest::testComputeFastSet()


### PR DESCRIPTION
Just hacked this together after reading #901

I modeled this after the --peer-id-prefix settings, is this a good approach for implementing this functionality? Should I model this option after a different option?

Also any suggestions on the name for this setting/parameter I named it since its similar to the "user agent". Maybe "bt-agent", "bt-user-agent", "bt-version", "peer-version", or "bt-extended-version"? Im hesitant to call it  anything with "version" since it is more of an identifier than anything else and may confuse users.
