### PR TITLE
Retry on HTTP 502

### DIFF
--- a/src/HttpSkipResponseCommand.cc
+++ b/src/HttpSkipResponseCommand.cc
@@ -220,6 +220,7 @@ bool HttpSkipResponseCommand::processResponse()
       }
       throw DL_RETRY_EX2(MSG_RESOURCE_NOT_FOUND,
                          error_code::RESOURCE_NOT_FOUND);
+    case 502:
     case 503:
       // Only retry if pretry-wait > 0. Hammering 'busy' server is not
       // a good idea.


### PR DESCRIPTION
HTTP error 502 is returned by reverse proxies when they fail to contact the upstream server. I think aria2 should retry like it does for 503.