### PR TITLE
Minor performance and memory issues fixed.

### DIFF
--- a/src/GZipFile.cc
+++ b/src/GZipFile.cc
@@ -158,7 +158,11 @@ int GZipFile::onVprintf(const char* format, va_list va)
       while (static_cast<ssize_t>(buflen_) < len) {
         buflen_ *= 2;
       }
-      buf_ = reinterpret_cast<char*>(realloc(buf_, buflen_));
+      char* buf = reinterpret_cast<char*>(realloc(buf_, buflen_));
+      if (!buf) {
+        return -1;
+      }
+      buf_ = buf;
     }
     else if (len < 0) {
       return len;

--- a/src/LongestSequencePieceSelector.cc
+++ b/src/LongestSequencePieceSelector.cc
@@ -81,7 +81,7 @@ bool LongestSequencePieceSelector::select(size_t& index,
     }
     nextIndex = endindex;
   }
-  if (mendindex - mstartindex > 0) {
+  if (mendindex != mstartindex) {
     index = mendindex - 1;
     return true;
   }

--- a/src/Netrc.cc
+++ b/src/Netrc.cc
@@ -168,12 +168,12 @@ void Netrc::parse(const std::string& path)
          iter != eoi; ++iter) {
       if (state == GET_TOKEN) {
         if (util::streq((*iter).first, (*iter).second, "machine")) {
-          storeAuthenticator(std::move(authenticator));
+          storeAuthenticator(authenticator);
           authenticator = make_unique<Authenticator>();
           state = SET_MACHINE;
         }
         else if (util::streq((*iter).first, (*iter).second, "default")) {
-          storeAuthenticator(std::move(authenticator));
+          storeAuthenticator(authenticator);
           authenticator = make_unique<DefaultAuthenticator>();
         }
         else {
@@ -220,7 +220,7 @@ void Netrc::parse(const std::string& path)
   if (state != GET_TOKEN) {
     throw DL_ABORT_EX("Netrc:parse error. EOF reached where a token expected.");
   }
-  storeAuthenticator(std::move(authenticator));
+  storeAuthenticator(authenticator);
 }
 
 void Netrc::storeAuthenticator(std::unique_ptr<Authenticator> authenticator)

--- a/src/OptionHandlerImpl.cc
+++ b/src/OptionHandlerImpl.cc
@@ -638,8 +638,8 @@ void OptimizeConcurrentDownloadsOptionHandler::parseArg(
     for (;;) {
       char* end;
       errno = 0;
-      strtod(sptr->c_str(), &end);
-      if (errno != 0 || sptr->c_str() + sptr->size() != end) {
+      double result = strtod(sptr->c_str(), &end);
+      if (errno == ERANGE || result == 0.0) {
         throw DL_ABORT_EX(fmt("Bad number '%s'", sptr->c_str()));
       }
       option.put(pref, *sptr);

--- a/src/Sqlite3CookieParser.cc
+++ b/src/Sqlite3CookieParser.cc
@@ -129,7 +129,7 @@ int cookieRowMapper(void* data, int columns, char** values, char** names)
       expiryTime,
       true, // persistent
       std::move(cookieDomain),
-      numericHost || (values[0] && values[0][0] != '.'), // hostOnly
+      numericHost || values[0][0] != '.', // hostOnly
       std::move(cookiePath), values[2] && strcmp(values[2], "1") == 0, // secure
       false,
       lastAccessTime // creation time. Set this later.


### PR DESCRIPTION
GZIPFile.cc: realloc() can delete the buf_ pointer, it is better to assign to a temporary variable and then check. Please change return -1 for whatever is appropriate, I've seen in case an issue happens negative integer is returned.

LongestSequencePieceSelector.cc: both are unsigned variables, simplifying the logic.

Netrc.cc: storeAuthenticator() function already executes the std::move() operation.

OptionHandlerImpl.cc: strtod() returns 0.0 if conversion was not possible, if numbre is too big it sets errno to ERANGE

Sqlite3CookieParser.cc: values[0] is always true, deleted from comparison to simplify the logic.
