### PR TITLE
Fix bug that signal handler does not work with libaria2

### DIFF
--- a/src/DownloadEngine.cc
+++ b/src/DownloadEngine.cc
@@ -150,14 +150,22 @@ void executeCommand(std::deque<std::unique_ptr<Command>>& commands,
 namespace {
 class GlobalHaltRequestedFinalizer {
 public:
-  GlobalHaltRequestedFinalizer() = default;
-  ~GlobalHaltRequestedFinalizer() { global::globalHaltRequested = 5; }
+  GlobalHaltRequestedFinalizer(bool oneshot) : oneshot_(oneshot) {}
+  ~GlobalHaltRequestedFinalizer()
+  {
+    if (!oneshot_) {
+      global::globalHaltRequested = 5;
+    }
+  }
+
+private:
+  bool oneshot_;
 };
 } // namespace
 
 int DownloadEngine::run(bool oneshot)
 {
-  GlobalHaltRequestedFinalizer ghrf;
+  GlobalHaltRequestedFinalizer ghrf(oneshot);
   while (!commands_.empty() || !routineCommands_.empty()) {
     if (!commands_.empty()) {
       waitData();


### PR DESCRIPTION
This commit fixes the bug that signal handler does not work with
libaria2 when aria2::RUN_ONCE is passed to aria2::run().