### PR TITLE
UnknownLengthPieceStorage: Completed Length

### DIFF
--- a/src/UnknownLengthPieceStorage.cc
+++ b/src/UnknownLengthPieceStorage.cc
@@ -210,6 +210,15 @@ bool UnknownLengthPieceStorage::isPieceUsed(size_t index)
   }
 }
 
+int64_t UnknownLengthPieceStorage::getCompletedLength()
+{
+  // TODO we have to return actual completed length here?
+  if (piece_) {
+    return piece_->getLength();
+  }
+  return totalLength_;
+}
+
 std::shared_ptr<DiskAdaptor> UnknownLengthPieceStorage::getDiskAdaptor()
 {
   return diskAdaptor_;

--- a/src/UnknownLengthPieceStorage.h
+++ b/src/UnknownLengthPieceStorage.h
@@ -162,11 +162,7 @@ public:
     return totalLength_;
   }
 
-  virtual int64_t getCompletedLength() CXX11_OVERRIDE
-  {
-    // TODO we have to return actual completed length here?
-    return totalLength_;
-  }
+  virtual int64_t getCompletedLength() CXX11_OVERRIDE;
 
   virtual int64_t getFilteredCompletedLength() CXX11_OVERRIDE
   {


### PR DESCRIPTION
Can aria2 show completed bytes in terminal while downloading item without Content-Length set?
I found that returning piece length could do it but I am not sure whether it is the proper way.