### PR TITLE
Fix build with LibreSSL 2.7

### DIFF
--- a/src/libssl_compat.h
+++ b/src/libssl_compat.h
@@ -37,7 +37,7 @@
 
 #include <openssl/opensslv.h>
 
-#if defined(LIBRESSL_VERSION_NUMBER)
+#if (defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER > 0x20700000fL)
 #define LIBRESSL_IN_USE 1
 #else // !defined(LIBRESSL_VERSION_NUMBER)
 #define LIBRESSL_IN_USE 0


### PR DESCRIPTION
LibreSSL 2.7 implements the OpenSSL 1.1 API

See also: https://bugs.freebsd.org/226843
Signed-off-by: Bernard Spil <brnrd@FreeBSD.org>