### PR TITLE
Print "No files to download" message as a log notice

### DIFF
--- a/src/Context.cc
+++ b/src/Context.cc
@@ -303,7 +303,7 @@ Context::Context(bool standalone, int argc, char** argv, const KeyVals& options)
 
   if (standalone && !op->getAsBool(PREF_ENABLE_RPC) && requestGroups.empty() &&
       !uriListParser) {
-    global::cout()->printf("%s\n", MSG_NO_FILES_TO_DOWNLOAD);
+    A2_LOG_NOTICE(MSG_NO_FILES_TO_DOWNLOAD);
   }
   else {
     if (!requestGroups.empty()) {


### PR DESCRIPTION
Allow --quiet to suppress this message, which is useful for scripted usage.

Context: https://github.com/AladW/aurutils/pull/367