### PR TITLE
gnutls: Fix bug that commonName is always empty

### DIFF
--- a/src/LibgnutlsTLSSession.cc
+++ b/src/LibgnutlsTLSSession.cc
@@ -341,6 +341,9 @@ int GnuTLSSession::tlsConnect(const std::string& hostname, TLSVersion& version,
             commonName.assign(altName, altNameLen);
           }
         }
+        else {
+          commonName.assign(altName, altNameLen);
+        }
       }
     }
     if (!net::verifyHostname(hostname, dnsNames, ipAddrs, commonName)) {


### PR DESCRIPTION
Fixes #1211 