### PR TITLE
Drop SSLv3.0 and TLSv1.0 and add TLSv1.3

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -1477,8 +1477,8 @@ Advanced Options
 .. option:: --min-tls-version=<VERSION>
 
   Specify minimum SSL/TLS version to enable.
-  Possible Values: ``SSLv3``, ``TLSv1``, ``TLSv1.1``, ``TLSv1.2``
-  Default: ``TLSv1``
+  Possible Values: ``TLSv1.1``, ``TLSv1.2``, ``TLSv1.3``
+  Default: ``TLSv1.2``
 
 .. option:: --multiple-interface=<INTERFACES>
 

--- a/src/AppleTLSSession.cc
+++ b/src/AppleTLSSession.cc
@@ -376,12 +376,6 @@ AppleTLSSession::AppleTLSSession(AppleTLSContext* ctx)
 
 #if defined(__MAC_10_8)
   switch (ctx->getMinTLSVersion()) {
-  case TLS_PROTO_SSL3:
-    (void)SSLSetProtocolVersionMin(sslCtx_, kSSLProtocol3);
-    break;
-  case TLS_PROTO_TLS10:
-    (void)SSLSetProtocolVersionMin(sslCtx_, kTLSProtocol1);
-    break;
   case TLS_PROTO_TLS11:
     (void)SSLSetProtocolVersionMin(sslCtx_, kTLSProtocol11);
     break;
@@ -394,12 +388,6 @@ AppleTLSSession::AppleTLSSession(AppleTLSContext* ctx)
 #else
   (void)SSLSetProtocolVersionEnabled(sslCtx_, kSSLProtocolAll, false);
   switch (ctx->getMinTLSVersion()) {
-  case TLS_PROTO_SSL3:
-    (void)SSLSetProtocolVersionEnabled(sslCtx_, kSSLProtocol3, true);
-  // fall through
-  case TLS_PROTO_TLS10:
-    (void)SSLSetProtocolVersionEnabled(sslCtx_, kTLSProtocol1, true);
-  // fall through
   case TLS_PROTO_TLS11:
     (void)SSLSetProtocolVersionEnabled(sslCtx_, kTLSProtocol11, true);
   // fall through
@@ -748,12 +736,6 @@ int AppleTLSSession::tlsConnect(const std::string& hostname,
                   protoToString(proto), suiteToString(suite).c_str()));
 
   switch (proto) {
-  case kSSLProtocol3:
-    version = TLS_PROTO_SSL3;
-    break;
-  case kTLSProtocol1:
-    version = TLS_PROTO_TLS10;
-    break;
   case kTLSProtocol11:
     version = TLS_PROTO_TLS11;
     break;

--- a/src/LibgnutlsTLSSession.cc
+++ b/src/LibgnutlsTLSSession.cc
@@ -34,6 +34,8 @@
 /* copyright --> */
 #include "LibgnutlsTLSSession.h"
 
+#include <cassert>
+
 #include <gnutls/x509.h>
 
 #include "TLSContext.h"
@@ -47,14 +49,14 @@ TLSVersion getProtocolFromSession(gnutls_session_t& session)
 {
   auto proto = gnutls_protocol_get_version(session);
   switch (proto) {
-  case GNUTLS_SSL3:
-    return TLS_PROTO_SSL3;
-  case GNUTLS_TLS1_0:
-    return TLS_PROTO_TLS10;
   case GNUTLS_TLS1_1:
     return TLS_PROTO_TLS11;
   case GNUTLS_TLS1_2:
     return TLS_PROTO_TLS12;
+#if GNUTLS_VERSION_NUMBER >= 0x030604
+  case GNUTLS_TLS1_3:
+    return TLS_PROTO_TLS13;
+#endif // GNUTLS_VERSION_NUMBER >= 0x030604
   default:
     return TLS_PROTO_NONE;
   }
@@ -133,16 +135,19 @@ int GnuTLSSession::init(sock_t sockfd)
 #else
   std::string pri = "SECURE128:+SIGN-RSA-SHA1";
   switch (tlsContext_->getMinTLSVersion()) {
+  case TLS_PROTO_TLS13:
+    pri += ":-VERS-TLS1.2";
+  // fall through
   case TLS_PROTO_TLS12:
     pri += ":-VERS-TLS1.1";
   // fall through
   case TLS_PROTO_TLS11:
     pri += ":-VERS-TLS1.0";
-  // fall through
-  case TLS_PROTO_TLS10:
     pri += ":-VERS-SSL3.0";
-  default:
     break;
+  default:
+    assert(0);
+    abort();
   };
   rv_ = gnutls_priority_set_direct(sslSession_, pri.c_str(), &err);
 #endif

--- a/src/LibsslTLSContext.cc
+++ b/src/LibsslTLSContext.cc
@@ -34,6 +34,7 @@
 /* copyright --> */
 #include "LibsslTLSContext.h"
 
+#include <cassert>
 #include <sstream>
 
 #include <openssl/err.h>
@@ -112,16 +113,21 @@ OpenSSLTLSContext::OpenSSLTLSContext(TLSSessionSide side, TLSVersion minVer)
 
   long ver_opts = 0;
   switch (minVer) {
+#ifdef TLS1_3_VERSION
+  case TLS_PROTO_TLS13:
+    ver_opts |= SSL_OP_NO_TLSv1_2;
+    // fall through
+#endif // TLS1_3_VERSION
   case TLS_PROTO_TLS12:
     ver_opts |= SSL_OP_NO_TLSv1_1;
   // fall through
   case TLS_PROTO_TLS11:
     ver_opts |= SSL_OP_NO_TLSv1;
-  // fall through
-  case TLS_PROTO_TLS10:
     ver_opts |= SSL_OP_NO_SSLv3;
-  default:
     break;
+  default:
+    assert(0);
+    abort();
   };
 
   // Disable SSLv2 and enable all workarounds for buggy servers

--- a/src/LibsslTLSSession.cc
+++ b/src/LibsslTLSSession.cc
@@ -195,16 +195,6 @@ int OpenSSLTLSSession::handshake(TLSVersion& version)
   }
 
   switch (SSL_version(ssl_)) {
-  case SSL3_VERSION:
-    version = TLS_PROTO_SSL3;
-    break;
-
-#ifdef TLS1_VERSION
-  case TLS1_VERSION:
-    version = TLS_PROTO_TLS10;
-    break;
-#endif // TLS1_VERSION
-
 #ifdef TLS1_1_VERSION
   case TLS1_1_VERSION:
     version = TLS_PROTO_TLS11;
@@ -216,6 +206,12 @@ int OpenSSLTLSSession::handshake(TLSVersion& version)
     version = TLS_PROTO_TLS12;
     break;
 #endif // TLS1_2_VERSION
+
+#ifdef TLS1_3_VERSION
+  case TLS1_3_VERSION:
+    version = TLS_PROTO_TLS13;
+    break;
+#endif // TLS1_3_VERSION
 
   default:
     version = TLS_PROTO_NONE;

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -513,8 +513,8 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
 #ifdef ENABLE_SSL
   {
     OptionHandler* op(new ParameterOptionHandler(
-        PREF_MIN_TLS_VERSION, TEXT_MIN_TLS_VERSION, A2_V_TLS10,
-        {A2_V_SSL3, A2_V_TLS10, A2_V_TLS11, A2_V_TLS12}));
+        PREF_MIN_TLS_VERSION, TEXT_MIN_TLS_VERSION, A2_V_TLS12,
+        {A2_V_TLS11, A2_V_TLS12, A2_V_TLS13}));
     op->addTag(TAG_ADVANCED);
     handlers.push_back(op);
   }

--- a/src/SocketCore.cc
+++ b/src/SocketCore.cc
@@ -971,23 +971,29 @@ bool SocketCore::tlsHandshake(TLSContext* tlsctx, const std::string& hostname)
       if (!hostname.empty()) {
         ss << ")";
       }
-      auto peerInfo = ss.str();
 
-      // 2. Issue any warnings
+      std::string tlsVersion;
       switch (ver) {
-      case TLS_PROTO_NONE:
-        A2_LOG_WARN(fmt(MSG_WARN_UNKNOWN_TLS_CONNECTION, peerInfo.c_str()));
+      case TLS_PROTO_TLS11:
+        tlsVersion = A2_V_TLS11;
         break;
-      case TLS_PROTO_SSL3:
-        A2_LOG_WARN(
-            fmt(MSG_WARN_OLD_TLS_CONNECTION, "SSLv3", peerInfo.c_str()));
+      case TLS_PROTO_TLS12:
+        tlsVersion = A2_V_TLS12;
+        break;
+      case TLS_PROTO_TLS13:
+        tlsVersion = A2_V_TLS13;
         break;
       default:
-        A2_LOG_DEBUG(fmt("Securely connected to %s", peerInfo.c_str()));
-        break;
+        assert(0);
+        abort();
       }
 
-      // 3. We're connected now!
+      auto peerInfo = ss.str();
+
+      A2_LOG_DEBUG(fmt("Securely connected to %s with %s", peerInfo.c_str(),
+                       tlsVersion.c_str()));
+
+      // 2. We're connected now!
       secure_ = A2_TLS_CONNECTED;
       return true;
     }

--- a/src/TLSContext.h
+++ b/src/TLSContext.h
@@ -45,10 +45,9 @@ enum TLSSessionSide { TLS_CLIENT, TLS_SERVER };
 
 enum TLSVersion {
   TLS_PROTO_NONE,
-  TLS_PROTO_SSL3,
-  TLS_PROTO_TLS10,
   TLS_PROTO_TLS11,
   TLS_PROTO_TLS12,
+  TLS_PROTO_TLS13,
 };
 
 class TLSContext {

--- a/src/WinTLSContext.cc
+++ b/src/WinTLSContext.cc
@@ -35,6 +35,7 @@
 
 #include "WinTLSContext.h"
 
+#include <cassert>
 #include <sstream>
 
 #include "BufferedFile.h"
@@ -74,52 +75,34 @@ WinTLSContext::WinTLSContext(TLSSessionSide side, TLSVersion ver)
   credentials_.grbitEnabledProtocols = 0;
   if (side_ == TLS_CLIENT) {
     switch (ver) {
-    case TLS_PROTO_SSL3:
-      credentials_.grbitEnabledProtocols |= SP_PROT_SSL3_CLIENT;
-    // fall through
-    case TLS_PROTO_TLS10:
-      credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_CLIENT;
-    // fall through
     case TLS_PROTO_TLS11:
       credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_1_CLIENT;
     // fall through
     case TLS_PROTO_TLS12:
       credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_2_CLIENT;
-    // fall through
-    default:
       break;
+    default:
+      assert(0);
+      abort();
     }
   }
   else {
     switch (ver) {
-    case TLS_PROTO_SSL3:
-      credentials_.grbitEnabledProtocols |= SP_PROT_SSL3_SERVER;
-    // fall through
-    case TLS_PROTO_TLS10:
-      credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_SERVER;
-    // fall through
     case TLS_PROTO_TLS11:
       credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_1_SERVER;
     // fall through
     case TLS_PROTO_TLS12:
       credentials_.grbitEnabledProtocols |= SP_PROT_TLS1_2_SERVER;
-    // fall through
-    default:
       break;
+    default:
+      assert(0);
+      abort();
     }
   }
 
-  switch (ver) {
-  case TLS_PROTO_SSL3:
-    // User explicitly wanted SSLv3 and therefore weak ciphers.
-    credentials_.dwMinimumCipherStrength = WEAK_CIPHER_BITS;
-    break;
-
-  default:
-    // Strong protocol versions: Use a minimum strength, which might be later
-    // refined using SCH_USE_STRONG_CRYPTO in the flags.
-    credentials_.dwMinimumCipherStrength = STRONG_CIPHER_BITS;
-  }
+  // Strong protocol versions: Use a minimum strength, which might be later
+  // refined using SCH_USE_STRONG_CRYPTO in the flags.
+  credentials_.dwMinimumCipherStrength = STRONG_CIPHER_BITS;
 
   setVerifyPeer(side_ == TLS_CLIENT);
 }

--- a/src/WinTLSSession.cc
+++ b/src/WinTLSSession.cc
@@ -788,12 +788,6 @@ restart:
     A2_LOG_INFO(
         fmt("WinTLS: connected with: %s", getCipherSuite(&handle_).c_str()));
     switch (getProtocolVersion(&handle_)) {
-    case 0x300:
-      version = TLS_PROTO_SSL3;
-      break;
-    case 0x301:
-      version = TLS_PROTO_TLS10;
-      break;
     case 0x302:
       version = TLS_PROTO_TLS11;
       break;
@@ -801,8 +795,8 @@ restart:
       version = TLS_PROTO_TLS12;
       break;
     default:
-      version = TLS_PROTO_NONE;
-      break;
+      assert(0);
+      abort();
     }
     return TLS_ERR_OK;
   }

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -150,10 +150,9 @@ const std::string V_ARC4("arc4");
 const std::string V_HTTP("http");
 const std::string V_HTTPS("https");
 const std::string V_FTP("ftp");
-const std::string A2_V_SSL3("SSLv3");
-const std::string A2_V_TLS10("TLSv1");
 const std::string A2_V_TLS11("TLSv1.1");
 const std::string A2_V_TLS12("TLSv1.2");
+const std::string A2_V_TLS13("TLSv1.3");
 
 PrefPtr PREF_VERSION = makePref("version");
 PrefPtr PREF_HELP = makePref("help");

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -107,10 +107,9 @@ extern const std::string V_ARC4;
 extern const std::string V_HTTP;
 extern const std::string V_HTTPS;
 extern const std::string V_FTP;
-extern const std::string A2_V_SSL3;
-extern const std::string A2_V_TLS10;
 extern const std::string A2_V_TLS11;
 extern const std::string A2_V_TLS12;
+extern const std::string A2_V_TLS13;
 
 extern PrefPtr PREF_VERSION;
 extern PrefPtr PREF_HELP;

--- a/src/util.cc
+++ b/src/util.cc
@@ -2470,19 +2470,16 @@ bool strless(const char* a, const char* b) { return strcmp(a, b) < 0; }
 #ifdef ENABLE_SSL
 TLSVersion toTLSVersion(const std::string& ver)
 {
-  if (ver == A2_V_SSL3) {
-    return TLS_PROTO_SSL3;
-  }
-  if (ver == A2_V_TLS10) {
-    return TLS_PROTO_TLS10;
-  }
   if (ver == A2_V_TLS11) {
     return TLS_PROTO_TLS11;
   }
   if (ver == A2_V_TLS12) {
     return TLS_PROTO_TLS12;
   }
-  return TLS_PROTO_TLS10;
+  if (ver == A2_V_TLS13) {
+    return TLS_PROTO_TLS13;
+  }
+  return TLS_PROTO_TLS12;
 }
 #endif // ENABLE_SSL
 


### PR DESCRIPTION
TLSv1.3 support is added for GNUTLS and OpenSSL.

Fixes #1382 
Closes #1167 
