### PR TITLE
Treat HTTP 429 codes like 503

### DIFF
--- a/src/HttpSkipResponseCommand.cc
+++ b/src/HttpSkipResponseCommand.cc
@@ -220,6 +220,7 @@ bool HttpSkipResponseCommand::processResponse()
       }
       throw DL_RETRY_EX2(MSG_RESOURCE_NOT_FOUND,
                          error_code::RESOURCE_NOT_FOUND);
+    case 429:
     case 502:
     case 503:
       // Only retry if pretry-wait > 0. Hammering 'busy' server is not


### PR DESCRIPTION
HTTP 429 is "Too Many Requests" and is used by services for various rate limiting strategies. If a request gets that response, then it should retry with the same delay instead of aborting.