### PR TITLE
Fix warnings on macOS.

### DIFF
--- a/src/DHTPeerAnnounceStorage.cc
+++ b/src/DHTPeerAnnounceStorage.cc
@@ -59,7 +59,7 @@ DHTPeerAnnounceStorage::DHTPeerAnnounceStorage()
 
 bool DHTPeerAnnounceStorage::InfoHashLess::
 operator()(const std::shared_ptr<DHTPeerAnnounceEntry>& lhs,
-           const std::shared_ptr<DHTPeerAnnounceEntry>& rhs)
+           const std::shared_ptr<DHTPeerAnnounceEntry>& rhs) const
 {
   return memcmp(lhs->getInfoHash(), rhs->getInfoHash(), DHT_ID_LENGTH) < 0;
 }

--- a/src/DHTPeerAnnounceStorage.h
+++ b/src/DHTPeerAnnounceStorage.h
@@ -54,7 +54,7 @@ private:
   class InfoHashLess {
   public:
     bool operator()(const std::shared_ptr<DHTPeerAnnounceEntry>& lhs,
-                    const std::shared_ptr<DHTPeerAnnounceEntry>& rhs);
+                    const std::shared_ptr<DHTPeerAnnounceEntry>& rhs) const;
   };
   typedef std::set<std::shared_ptr<DHTPeerAnnounceEntry>, InfoHashLess>
       DHTPeerAnnounceEntrySet;

--- a/src/SessionSerializer.cc
+++ b/src/SessionSerializer.cc
@@ -143,7 +143,7 @@ namespace {
 template <typename T> class Unique {
   typedef T type;
   struct PointerCmp {
-    inline bool operator()(const type* x, const type* y) { return *x < *y; }
+    inline bool operator()(const type* x, const type* y) const { return *x < *y; }
   };
   std::set<const type*, PointerCmp> known;
 


### PR DESCRIPTION
fix the warnings on macOS

> the specified comparator type does not provide a const call operator