### PR TITLE
Reset sessionDownloadLength and sessionUploadLength on download start

### DIFF
--- a/src/NetStat.cc
+++ b/src/NetStat.cc
@@ -110,6 +110,8 @@ void NetStat::reset()
   uploadSpeed_.reset();
   downloadStartTime_ = global::wallclock();
   status_ = IDLE;
+  sessionDownloadLength_ = 0;
+  sessionUploadLength_ = 0;
 }
 
 void NetStat::downloadStart()


### PR DESCRIPTION
This commit resets sessionDownloadLength and sessionUploadLength when
a download restarted (including unpause RPC method).

Fixes #1486