### PR TITLE
Upgrade Chromium cookie store support to version 11

### DIFF
--- a/src/Sqlite3CookieParserImpl.cc
+++ b/src/Sqlite3CookieParserImpl.cc
@@ -59,14 +59,20 @@ Sqlite3ChromiumCookieParser::~Sqlite3ChromiumCookieParser() = default;
 
 const char* Sqlite3ChromiumCookieParser::getQuery() const
 {
-  // chrome's time is microsecond resolution, and its epoc is Jan 1
-  // 00:00:00 +0000 1601, so we have to convert it to second from UNIX
-  // epoc.  11644473600 is the second between chrome's epoc and UNIX
-  // epoc.  e.g., date +%s -d 'Jan 1 00:00:00 +0000 1601'
-  return "SELECT host_key, path, secure, expires_utc / 1000000 - 11644473600 "
-         "as expires_utc, name, value, "
-         "last_access_utc / 1000000 - 11644473600 as last_access_utc"
-         " FROM cookies";
+  // Chrome stores time in microsecond resolution, and its epoch is Jan 1
+  // 00:00:00 +0000 1601, so we have to convert it to seconds from UNIX epoch.
+  // 11644473600 is the number of seconds between Chrome's epoch and the UNIX
+  // epoch, e.g. `date +%s -d 'Jan 1 00:00:00 +0000 1601'`
+
+  // Ideally, the SQLite3 cookie parser API would first run an identification
+  // process to determine the format and version of the cookie store, but it's
+  // not currently designed that way. The following query is specifically for
+  // Chromium cookie stores with latest_compatible_db_version = 11.
+  return ""
+    "   SELECT host_key, path, is_secure, expires_utc / 1000000 - 11644473600 "
+    "       as expires_utc, name, value, "
+    "       last_access_utc / 1000000 - 11644473600 as last_access_utc "
+    "   FROM cookies";
 }
 
 } // namespace aria2


### PR DESCRIPTION
Edge, Chrome, and Opera are all using this format now.

We cannot dynamically craft a query that selects from `secure` or `is_secure` depending on `meta.last_compatible_db_version` as the SQLite query builder first parses and validates all columns named in a query before executing any part of it and does not have the equivalent of `eval`. 

If `getQuery()` instead returned a query that returned the *text* of a query, that would be OK but for now I think this is in the best interest of most aria2 users.