### PR TITLE
Remove the ipv4 address shortcut and adds an any address shortcut.

### DIFF
--- a/src/AsyncNameResolverMan.cc
+++ b/src/AsyncNameResolverMan.cc
@@ -151,14 +151,10 @@ int AsyncNameResolverMan::getStatus() const
 {
   size_t success = 0;
   size_t error = 0;
-  bool ipv4Success = false;
   for (size_t i = 0; i < numResolver_; ++i) {
     switch (asyncNameResolver_[i]->getStatus()) {
     case AsyncNameResolver::STATUS_SUCCESS:
       ++success;
-      if (asyncNameResolver_[i]->getFamily() == AF_INET) {
-        ipv4Success = true;
-      }
       break;
     case AsyncNameResolver::STATUS_ERROR:
       ++error;
@@ -167,12 +163,7 @@ int AsyncNameResolverMan::getStatus() const
       break;
     }
   }
-  // If we got a IPv4 lookup response, we don't wait for a IPv6 lookup
-  // response. This is because DNS servers may drop AAAA queries and we
-  // have to wait for a long time before timeout. We don't do the
-  // inverse, because, based on today's deployment of DNS servers,
-  // almost all of them can respond to A queries just fine.
-  if ((success && ipv4Success) || success == numResolver_) {
+  if (success > 0) {
     return 1;
   }
   else if (error == numResolver_) {


### PR DESCRIPTION
The original async resolver code blocks forever when the domain resolved has only ipv6 address, and as ipv6 is already widely deployed, the ipv4 shortcut can be replaced with a catch-all one. 