### PR TITLE
Check NO_COLOR to set default value of --enable-color flag

### DIFF
--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -258,7 +258,9 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
 #endif // ENABLE_ASYNC_DNS
   {
     OptionHandler* op(new BooleanOptionHandler(PREF_ENABLE_COLOR,
-                                               TEXT_ENABLE_COLOR, A2_V_TRUE,
+                                               TEXT_ENABLE_COLOR,
+                                               getenv("NO_COLOR") ?
+                                               A2_V_FALSE : A2_V_TRUE,
                                                OptionHandler::OPT_ARG));
     op->addTag(TAG_ADVANCED);
     handlers.push_back(op);


### PR DESCRIPTION
There is a site called [no-color.org](https://no-color.org/) that wants to popularize the `NO_COLOR` environmental variable as a way to disable color-output in various CLI programmes. As far as I understand, aria2 uses it's own color-generator, and so I tried to add support for the `NO_COLOR` convention in aria2c.

Just as a disclaimer: I'm _not_ a C++ developer, and I hope my C experience is "acceptable" for this project.