### PR TITLE
Support segmented downloads with "chunked" transfer-encoding.

### DIFF
--- a/src/ChunkedDecodingStreamFilter.cc
+++ b/src/ChunkedDecodingStreamFilter.cc
@@ -84,10 +84,31 @@ ChunkedDecodingStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
                                        const unsigned char* inbuf, size_t inlen)
 {
   ssize_t outlen = 0;
-  size_t i;
   bytesProcessed_ = 0;
-  for (i = 0; i < inlen; ++i) {
-    unsigned char c = inbuf[i];
+  while (bytesProcessed_ < inlen) {
+    if (state_ == CHUNKS_COMPLETE) {
+      break;
+    }
+    if (state_ == CHUNK) {
+      int64_t readlen = std::min(chunkRemaining_,
+                                 static_cast<int64_t>(inlen - bytesProcessed_));
+      outlen += getDelegate()->transform(out, segment, inbuf + bytesProcessed_,
+                                         readlen);
+      int64_t processedlen = getDelegate()->getBytesProcessed();
+      bytesProcessed_ += processedlen;
+      chunkRemaining_ -= processedlen;
+      if (chunkRemaining_ == 0) {
+        state_ = PREV_CHUNK_CR;
+      }
+      if (processedlen < readlen) {
+        // segment download finished
+        break;
+      }
+      continue;
+    }
+    // The following states consume single char
+    unsigned char c = inbuf[bytesProcessed_];
+    bytesProcessed_++;
     switch (state_) {
     case PREV_CHUNK_SIZE:
       if (util::isHexDigit(c)) {
@@ -136,17 +157,6 @@ ChunkedDecodingStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
                           "missing LF at the end of chunk size");
       }
       break;
-    case CHUNK: {
-      int64_t readlen =
-          std::min(chunkRemaining_, static_cast<int64_t>(inlen - i));
-      outlen += getDelegate()->transform(out, segment, inbuf + i, readlen);
-      chunkRemaining_ -= readlen;
-      i += readlen - 1;
-      if (chunkRemaining_ == 0) {
-        state_ = PREV_CHUNK_CR;
-      }
-      break;
-    }
     case PREV_CHUNK_CR:
       if (c == '\r') {
         state_ = PREV_CHUNK_LF;
@@ -203,15 +213,12 @@ ChunkedDecodingStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
                           "missing LF at the end of chunks");
       }
       break;
-    case CHUNKS_COMPLETE:
-      goto fin;
     default:
       // unreachable
       assert(0);
     }
   }
-fin:
-  bytesProcessed_ += i;
+
   return outlen;
 }
 

--- a/src/GZipDecodingStreamFilter.h
+++ b/src/GZipDecodingStreamFilter.h
@@ -37,6 +37,7 @@
 
 #include "StreamFilter.h"
 #include <zlib.h>
+#include <vector>
 
 #include "a2functional.h"
 
@@ -47,11 +48,13 @@ class GZipDecodingStreamFilter : public StreamFilter {
 private:
   z_stream* strm_;
 
+  std::vector<unsigned char> outbuf_;
+
   bool finished_;
 
   size_t bytesProcessed_;
 
-  static const size_t OUTBUF_LENGTH = 16_k;
+  static const size_t OUTBUF_CAPACITY = 16_k;
 
 public:
   GZipDecodingStreamFilter(std::unique_ptr<StreamFilter> delegate = nullptr);

--- a/src/HttpHeader.cc
+++ b/src/HttpHeader.cc
@@ -102,7 +102,7 @@ Range HttpHeader::getRange() const
         throw DOWNLOAD_FAILURE_EXCEPTION(fmt(EX_TOO_LARGE_FILE, contentLength));
       }
       else if (contentLength == 0) {
-        return Range();
+        return Range(0, 0, 0);
       }
       else {
         return Range(0, contentLength - 1, contentLength);

--- a/src/HttpHeaderProcessor.cc
+++ b/src/HttpHeaderProcessor.cc
@@ -457,7 +457,6 @@ fin:
   // when range is set.
   if (result_->defined(HttpHeader::TRANSFER_ENCODING)) {
     result_->remove(HttpHeader::CONTENT_LENGTH);
-    result_->remove(HttpHeader::CONTENT_RANGE);
   }
 
   return true;

--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -213,6 +213,9 @@ std::string HttpRequest::createRequest()
     }
     builtinHds.emplace_back("Range:", rangeHeader);
   }
+  else if (!segment_ && getMethod() == "GET") {
+    builtinHds.emplace_back("Range:", "bytes=0-");
+  }
   if (proxyRequest_) {
     if (request_->isKeepAliveEnabled() || request_->isPipeliningEnabled()) {
       builtinHds.emplace_back("Connection:", "Keep-Alive");

--- a/src/HttpResponse.cc
+++ b/src/HttpResponse.cc
@@ -74,6 +74,10 @@ void HttpResponse::validateResponse() const
   switch (statusCode) {
   case 200: // OK
   case 206: { // Partial Content
+    if (statusCode == 206 && !httpHeader_->defined(HttpHeader::CONTENT_RANGE)) {
+      throw DL_ABORT_EX2("Content-Range header not specified in 206 response",
+                         error_code::HTTP_PROTOCOL_ERROR);
+    }
     // compare the received range against the requested range
     auto responseRange = httpHeader_->getRange();
     if (responseRange.isDefined &&

--- a/src/HttpResponse.h
+++ b/src/HttpResponse.h
@@ -97,6 +97,8 @@ public:
 
   int64_t getContentLength() const;
 
+  bool isEntityLengthKnown() const;
+
   int64_t getEntityLength() const;
 
   // Returns type "/" subtype. The parameter is removed.

--- a/src/HttpResponseCommand.cc
+++ b/src/HttpResponseCommand.cc
@@ -272,9 +272,6 @@ bool HttpResponseCommand::executeInternal()
     // update last modified time
     updateLastModifiedTime(httpResponse->getLastModifiedTime());
 
-    // If both transfer-encoding and total length is specified, we
-    // should have ignored total length.  In this case, we can not do
-    // segmented downloading
     if (totalLength == 0 || shouldInflateContentEncoding(httpResponse.get())) {
       // we ignore content-length when inflate is required
       fe->setLength(0);

--- a/src/Range.cc
+++ b/src/Range.cc
@@ -36,10 +36,11 @@
 
 namespace aria2 {
 
-Range::Range() : startByte(0), endByte(0), entityLength(0) {}
+Range::Range() : startByte(0), endByte(0), entityLength(0), isDefined(false) {}
 
 Range::Range(int64_t startByte, int64_t endByte, int64_t entityLength)
-    : startByte(startByte), endByte(endByte), entityLength(entityLength)
+    : startByte(startByte), endByte(endByte), entityLength(entityLength),
+      isDefined(true)
 {
 }
 
@@ -53,6 +54,7 @@ Range& Range::operator=(const Range& c)
     startByte = c.startByte;
     endByte = c.endByte;
     entityLength = c.entityLength;
+    isDefined = c.isDefined;
   }
   return *this;
 }
@@ -60,7 +62,7 @@ Range& Range::operator=(const Range& c)
 bool Range::operator==(const Range& range) const
 {
   return startByte == range.startByte && endByte == range.endByte &&
-         entityLength == range.entityLength;
+         entityLength == range.entityLength && isDefined == range.isDefined;
 }
 
 bool Range::operator!=(const Range& range) const { return !(*this == range); }

--- a/src/Range.h
+++ b/src/Range.h
@@ -45,6 +45,7 @@ struct Range {
   int64_t startByte;
   int64_t endByte;
   int64_t entityLength;
+  bool isDefined;
 
   Range();
 

--- a/test/HttpHeaderProcessorTest.cc
+++ b/test/HttpHeaderProcessorTest.cc
@@ -224,7 +224,7 @@ void HttpHeaderProcessorTest::testGetHttpResponseHeader_teAndCl()
   CPPUNIT_ASSERT_EQUAL(std::string("chunked"),
                        httpHeader->find(HttpHeader::TRANSFER_ENCODING));
   CPPUNIT_ASSERT(!httpHeader->defined(HttpHeader::CONTENT_LENGTH));
-  CPPUNIT_ASSERT(!httpHeader->defined(HttpHeader::CONTENT_RANGE));
+  CPPUNIT_ASSERT(httpHeader->defined(HttpHeader::CONTENT_RANGE));
 }
 
 void HttpHeaderProcessorTest::testBeyondLimit()


### PR DESCRIPTION
For this purpose,
1. b301daa is necessary to get file size info (in '`Content-Range`') from the server because '`Content-Length`' can not be specified with chunked encoding.
2. 6046b7c to not ignore `Content-Range`.

Please see #1576.

This builds on #1583.