### PR TITLE
Fix segfault when time_t is 64bit on 32bit arch (#1666)

### DIFF
--- a/src/ServerStat.cc
+++ b/src/ServerStat.cc
@@ -183,10 +183,10 @@ bool ServerStat::operator==(const ServerStat& serverStat) const
 std::string ServerStat::toString() const
 {
   return fmt("host=%s, protocol=%s, dl_speed=%d, sc_avg_speed=%d,"
-             " mc_avg_speed=%d, last_updated=%ld, counter=%d, status=%s",
+             " mc_avg_speed=%d, last_updated=%" PRId64 ", counter=%d, status=%s",
              getHostname().c_str(), getProtocol().c_str(), getDownloadSpeed(),
              getSingleConnectionAvgSpeed(), getMultiConnectionAvgSpeed(),
-             getLastUpdated().getTimeFromEpoch(), getCounter(),
+             (int64_t)getLastUpdated().getTimeFromEpoch(), getCounter(),
              STATUS_STRING[getStatus()]);
 }
 


### PR DESCRIPTION
On some platforms, like with musl libc, time_t may be 64 bit even on
32bit platforms. Fix segfault by convert time_t to 64 bit and use 64bit
format modifier instead of assume time_t is %ld