### PR TITLE
Restart terminated slow connections

### DIFF
--- a/src/DownloadCommand.cc
+++ b/src/DownloadCommand.cc
@@ -306,7 +306,7 @@ void DownloadCommand::checkLowestDownloadSpeed() const
           startupIdleTime_) {
     int nowSpeed = peerStat_->calculateDownloadSpeed();
     if (nowSpeed <= lowestDownloadSpeedLimit_) {
-      throw DL_ABORT_EX2(fmt(EX_TOO_SLOW_DOWNLOAD_SPEED, nowSpeed,
+      throw DL_RETRY_EX2(fmt(EX_TOO_SLOW_DOWNLOAD_SPEED, nowSpeed,
                              lowestDownloadSpeedLimit_,
                              getRequest()->getHost().c_str()),
                          error_code::TOO_SLOW_DOWNLOAD_SPEED);


### PR DESCRIPTION
Restart connection on low speed dropout.

Before this pr the number of open connections to a server will slowly decrease until there are none left.
After this pr aria2c will restart all connections that were terminated because of being to slow.