### PR TITLE
Fix a wait in the retry for HTTP 404 error

### DIFF
--- a/src/AbstractCommand.cc
+++ b/src/AbstractCommand.cc
@@ -386,7 +386,10 @@ bool AbstractCommand::execute()
       return true;
     }
 
-    if (err.getErrorCode() == error_code::HTTP_SERVICE_UNAVAILABLE) {
+    if (err.getErrorCode() == error_code::HTTP_SERVICE_UNAVAILABLE ||
+        err.getErrorCode() == error_code::RESOURCE_NOT_FOUND) {
+      A2_LOG_DEBUG(fmt(MSG_RETRY_WAITING, getCuid(), getOption()->getAsInt(PREF_RETRY_WAIT),
+        req_->getUri().c_str()));
       Timer wakeTime(global::wallclock());
       wakeTime.advance(
           std::chrono::seconds(getOption()->getAsInt(PREF_RETRY_WAIT)));

--- a/src/message.h
+++ b/src/message.h
@@ -47,6 +47,7 @@
 #define MSG_SENDING_REQUEST "CUID#%" PRId64 " - Requesting:\n%s"
 #define MSG_RECEIVE_RESPONSE "CUID#%" PRId64 " - Response received:\n%s"
 #define MSG_DOWNLOAD_ABORTED "CUID#%" PRId64 " - Download aborted. URI=%s"
+#define MSG_RETRY_WAITING "CUID#%" PRId64 " - Waiting (%d sec) for retry of the download. URI=%s"
 #define MSG_RESTARTING_DOWNLOAD "CUID#%" PRId64 " - Restarting the download. URI=%s"
 #define MSG_TORRENT_DOWNLOAD_ABORTED "CUID#%" PRId64 " - Download aborted."
 #define MSG_MAX_TRY                                                     \


### PR DESCRIPTION
If HTTP 404 error is hit then _aria2_ retries **max-file-not-found** times to download but without to wait **retry-wait** seconds (as in the case of the HTTP 503, for example). There was such an error before and it was fixed but partially only (the fix raises the exception **DL_RETRY_EX2** but it does not start a waiting itself). The fix added a waiting, together with **HTTP_SERVICE_UNAVAILABLE** error (HTTP 503).

Also the fix adds logging of it under the DEBUG severity.