### PR TITLE
Exclude checked-in .m4 files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@
 *.he
 depcomp
 *.m4
+!m4/aria2_arg.m4
+!m4/ax_check_compile_flag.m4
+!m4/ax_cxx_compile_stdcxx_11.m4
+!m4/fallocate.m4
 Makefile
 Makefile.in
 missing


### PR DESCRIPTION
It seems bad to have a file which is part of the repository excluded
from git status.

I found this by attempting to use `git clean -dXf` to remove temporary files, and then getting errors.