### PR TITLE
fix memory leak when exception thrown

### DIFF
--- a/src/Piece.cc
+++ b/src/Piece.cc
@@ -347,8 +347,13 @@ void Piece::updateWrCache(WrDiskCache* diskCache, unsigned char* data,
   cell->len = len;
   cell->capacity = capacity;
   bool rv;
-  rv = wrCache_->cacheData(cell);
-  assert(rv);
+  try {
+    rv = wrCache_->cacheData(cell);
+    assert(rv);
+  } catch (RecoverableException& e) {
+    delete cell;
+    throw;
+  }
   rv = diskCache->update(wrCache_.get(), len);
   assert(rv);
 }


### PR DESCRIPTION
The function `cacheData` involves file operations (`A2_LOG_DEBUG`) which might throw an exception.

In that case, `cell` (as well as `dataCopy`) is not freed and memory leak occurs.