### PR TITLE
Fix header in --http-accept-gzip documentation

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -433,7 +433,7 @@ HTTP Specific Options
 
 .. option:: --http-accept-gzip [true|false]
 
-  Send ``Accept: deflate, gzip`` request header and inflate response if
+  Send ``Accept-Encoding: deflate, gzip`` request header and inflate response if
   remote server responds with ``Content-Encoding: gzip`` or
   ``Content-Encoding: deflate``.  Default: ``false``
 

--- a/doc/manual-src/pt/aria2c.rst
+++ b/doc/manual-src/pt/aria2c.rst
@@ -407,7 +407,7 @@ Opções Específicas de HTTP e HTTPS
 
 .. option:: --http-accept-gzip [true|false]
 
-  Envia cabeçalho requisição ``Accept: deflate, gzip`` e faz (inflate) se
+  Envia cabeçalho requisição ``Accept-Encoding: deflate, gzip`` e faz (inflate) se
   o servidor remoto responder com  ``Content-Encoding: gzip`` ou 
   ``Content-Encoding: deflate``.  Padrão: ``false``
 

--- a/doc/manual-src/ru/aria2c.rst
+++ b/doc/manual-src/ru/aria2c.rst
@@ -451,7 +451,7 @@ HTTP(S)/FTP, они тут же могут выгружаться в BitTorrent-
 
 .. option:: --http-accept-gzip [true|false]
 
-  Посылать ``Accept: deflate, gzip`` в запросе-заголовке и добавлять в ответ,
+  Посылать ``Accept-Encoding: deflate, gzip`` в запросе-заголовке и добавлять в ответ,
   если удаленный сервер ответит ``Content-Encoding: gzip`` или
   ``Content-Encoding: deflate``.
   По умолчанию: 'false

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -723,9 +723,9 @@
 #define TEXT_DHT_MESSAGE_TIMEOUT                \
   _(" --dht-message-timeout=SEC    Set timeout in seconds.")
 #define TEXT_HTTP_ACCEPT_GZIP                   \
-  _(" --http-accept-gzip[=true|false] Send 'Accept: deflate, gzip' request header\n" \
-    "                              and inflate response if remote server responds\n" \
-    "                              with 'Content-Encoding: gzip' or\n"  \
+  _(" --http-accept-gzip[=true|false] Send 'Accept-Encoding: deflate, gzip' request\n" \
+    "                              header and inflate response if remote server\n" \
+    "                              responds with 'Content-Encoding: gzip' or\n"  \
     "                              'Content-Encoding: deflate'.")
 #define TEXT_SAVE_SESSION                       \
   _(" --save-session=FILE          Save error/unfinished downloads to FILE on exit.\n" \


### PR DESCRIPTION
Hiya,

I noticed that the docs for `--http-accept-gzip` suggested that aria2c would set the `Accept` header to request a gzip response, rather than the expected `Accept-Encoding`. I thought this was odd, so tested it myself, and I found that the docs are incorrect. In fact aria2c sets the correct header: `Accept-Encoding: deflate, gzip`.

I think these are the only places where it was mentioned incorrectly.