### PR TITLE
Support SOCSK5 proxy for BT UDP Trackers and DHT connections

### DIFF
--- a/src/DHTConnectionSocksProxyImpl.cc
+++ b/src/DHTConnectionSocksProxyImpl.cc
@@ -165,7 +165,7 @@ ssize_t DHTConnectionSocksProxyImpl::receiveMessage(unsigned char* data,
                                                     uint16_t& port)
 {
   Endpoint remoteEndpoint;
-  size_t resLen = len + family_ == AF_INET ? 10 : 22;
+  size_t resLen = len + (family_ == AF_INET ? 10 : 22);
   std::string buf;
   buf.resize(resLen);
   ssize_t length = getSocket()->readDataFrom(&buf[0], resLen, remoteEndpoint);
@@ -175,14 +175,14 @@ ssize_t DHTConnectionSocksProxyImpl::receiveMessage(unsigned char* data,
 
   // unencapsulate SOCKS5 UDP header if has
   if (length > (family_ == AF_INET ? 10 : 22) &&
-      buf.substr(0, 3) == "\x00\x00\x00" &&
+      buf.substr(0, 3) == std::string("\x00\x00\x00", 3) &&
       buf[3] == (family_ == AF_INET ? '\x01' : '\x04')) {
     if (family_ == AF_INET) {
       char addrBuf[20];
       inetNtop(AF_INET, &buf[4], addrBuf, 20);
       host = std::string(addrBuf);
       port = ntohs(*(reinterpret_cast<uint16_t*>(&buf[8])));
-      memcpy(data, buf.c_str(), length - 10);
+      memcpy(data, &buf[10], length - 10);
       return length - 10;
     }
     else {
@@ -190,7 +190,7 @@ ssize_t DHTConnectionSocksProxyImpl::receiveMessage(unsigned char* data,
       inetNtop(AF_INET6, &buf[4], addrBuf, 50);
       host = std::string(addrBuf);
       port = ntohs(*(reinterpret_cast<uint16_t*>(&buf[20])));
-      memcpy(data, buf.c_str(), length - 22);
+      memcpy(data, &buf[22], length - 22);
       return length - 22;
     }
   }

--- a/src/DHTConnectionSocksProxyImpl.cc
+++ b/src/DHTConnectionSocksProxyImpl.cc
@@ -1,0 +1,229 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#include "DHTConnectionSocksProxyImpl.h"
+
+#include <netinet/in.h>
+#include <cstring>
+
+#include "SocketCore.h"
+
+namespace aria2 {
+
+DHTConnectionSocksProxyImpl::DHTConnectionSocksProxyImpl(int family)
+    : DHTConnectionImpl(family),
+      family_(family),
+      proxySocket_(std::make_unique<SocketCore>())
+{
+}
+
+DHTConnectionSocksProxyImpl::~DHTConnectionSocksProxyImpl() = default;
+
+bool DHTConnectionSocksProxyImpl::startProxy(const std::string& host,
+                                             uint16_t port,
+                                             const std::string& user,
+                                             const std::string& passwd,
+                                             const std::string& listenAddr,
+                                             uint16_t listenPort)
+{
+  proxySocket_->establishConnection(host, port);
+  proxySocket_->setBlockingMode();
+  Endpoint proxyEndpoint;
+  unsigned char resBuf[10];
+
+  // Authentication negotiation
+  bool noAuth = user.empty() || passwd.empty();
+  if (noAuth) {
+    std::string req("\x05\x01\x00", 3);
+    size_t resLen = 2;
+    proxySocket_->writeData(req);
+    proxySocket_->readData(resBuf, resLen);
+    if (resBuf[1] != '\x00') {
+      proxySocket_->closeConnection();
+      return false;
+    }
+  }
+  else {
+    std::string req("\x05\x02\x00\x02", 4);
+    size_t resLen = 2;
+    proxySocket_->writeData(req);
+    Endpoint proxyEndpoint;
+    proxySocket_->readData(resBuf, resLen);
+    if (resBuf[1] != '\x02' && resBuf[1] != '\x00') {
+      proxySocket_->closeConnection();
+      return false;
+    }
+
+    // Username/password authentication
+    if (resBuf[1] == '\x02') {
+      req = std::string("\x01", 1);
+      req.push_back(static_cast<char>(user.length()));
+      req += user;
+      req.push_back(static_cast<char>(passwd.length()));
+      req += passwd;
+      size_t resLen = 2;
+      proxySocket_->writeData(req);
+      proxySocket_->readData(resBuf, resLen);
+      if (resBuf[1] != '\x00') {
+        proxySocket_->closeConnection();
+        return false;
+      }
+    }
+  }
+
+  // UDP associate
+  std::string req("\x05\x03\x00", 3);
+  if (family_ == AF_INET) {
+    req.push_back('\x01');
+    char addrBuf[10];
+    net::getBinAddr(addrBuf, listenAddr);
+    req.append(addrBuf, 4);
+  }
+  else {
+    req.push_back('\x04');
+    char addrBuf[20];
+    net::getBinAddr(addrBuf, listenAddr);
+    req.append(addrBuf, 16);
+  }
+  uint16_t listenPortBuf = htons(listenPort);
+  req.append(reinterpret_cast<const char*>(&listenPortBuf), 2);
+  size_t resLen = 5;
+  proxySocket_->writeData(req);
+  proxySocket_->readData(resBuf, resLen);
+  if (resBuf[1] != '\x00') {
+    proxySocket_->closeConnection();
+    return false;
+  }
+  if (resBuf[3] == '\x01') {
+    unsigned char addrBuf[6];
+    addrBuf[0] = resBuf[4];
+    resLen = 5;
+    proxySocket_->readData(addrBuf + 1, resLen);
+    char addrStrBuf[20];
+    inetNtop(AF_INET, addrBuf, addrStrBuf, 20);
+    bndAddr_ = std::string(addrStrBuf);
+    bndPort_ = ntohs(*reinterpret_cast<uint16_t*>(addrBuf + 4));
+  }
+  else if (resBuf[3] == '\x04') {
+    unsigned char addrBuf[18];
+    addrBuf[0] = resBuf[4];
+    resLen = 17;
+    proxySocket_->readData(addrBuf + 1, resLen);
+    char addrStrBuf[50];
+    inetNtop(AF_INET6, addrBuf, addrStrBuf, 50);
+    bndAddr_ = std::string(addrStrBuf);
+    bndPort_ = ntohs(*reinterpret_cast<uint16_t*>(addrBuf + 16));
+  }
+  else if (resBuf[3] == '\x03') {
+    bndAddr_ = std::string(resBuf[4] + 2, '\x00');
+    resLen = resBuf[4] + 2;
+    proxySocket_->readData(&bndAddr_[0], resLen);
+    bndPort_ = ntohs(*reinterpret_cast<uint16_t*>(&bndAddr_[0] + resBuf[4]));
+    bndAddr_.resize(resBuf[4]);
+  }
+  else {
+    proxySocket_->closeConnection();
+    return false;
+  }
+  return true;
+}
+
+ssize_t DHTConnectionSocksProxyImpl::receiveMessage(unsigned char* data,
+                                                    size_t len,
+                                                    std::string& host,
+                                                    uint16_t& port)
+{
+  Endpoint remoteEndpoint;
+  size_t resLen = len + family_ == AF_INET ? 10 : 22;
+  std::string buf;
+  buf.resize(resLen);
+  ssize_t length = getSocket()->readDataFrom(&buf[0], resLen, remoteEndpoint);
+  if (length == 0) {
+    return length;
+  }
+
+  // unencapsulate SOCKS5 UDP header if has
+  if (length > (family_ == AF_INET ? 10 : 22) &&
+      buf.substr(0, 3) == "\x00\x00\x00" &&
+      buf[3] == (family_ == AF_INET ? '\x01' : '\x04')) {
+    if (family_ == AF_INET) {
+      char addrBuf[20];
+      inetNtop(AF_INET, &buf[4], addrBuf, 20);
+      host = std::string(addrBuf);
+      port = ntohs(*(reinterpret_cast<uint16_t*>(&buf[8])));
+      memcpy(data, buf.c_str(), length - 10);
+      return length - 10;
+    }
+    else {
+      char addrBuf[50];
+      inetNtop(AF_INET6, &buf[4], addrBuf, 50);
+      host = std::string(addrBuf);
+      port = ntohs(*(reinterpret_cast<uint16_t*>(&buf[20])));
+      memcpy(data, buf.c_str(), length - 22);
+      return length - 22;
+    }
+  }
+  else {
+    host = remoteEndpoint.addr;
+    port = remoteEndpoint.port;
+    return length;
+  }
+}
+
+ssize_t DHTConnectionSocksProxyImpl::sendMessage(const unsigned char* data,
+                                                 size_t len,
+                                                 const std::string& host,
+                                                 uint16_t port)
+{
+  std::string buf;
+  if (family_ == AF_INET) {
+    buf.resize(10);
+    buf[3] = '\x01';
+    // host is got from receiveMessage(). And as socket is binded according to
+    // family, host should be the same family as family_. Omit family checking.
+    net::getBinAddr(&buf[4], host);
+    *(reinterpret_cast<uint16_t*>(&buf[8])) = htons(port);
+    buf.append(reinterpret_cast<const char*>(data), len);
+  }
+  else {
+    buf.resize(22);
+    buf[3] = '\x04';
+    net::getBinAddr(&buf[4], host);
+    *(reinterpret_cast<uint16_t*>(&buf[20])) = htons(port);
+    buf.append(reinterpret_cast<const char*>(data), len);
+  }
+  return getSocket()->writeData(&buf[0], buf.length(), bndAddr_, bndPort_);
+}
+
+} // namespace aria2

--- a/src/DHTConnectionSocksProxyImpl.h
+++ b/src/DHTConnectionSocksProxyImpl.h
@@ -1,0 +1,76 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#ifndef D_DHT_CONNECTION_SOCKS_PROXY_IMPL_H
+#define D_DHT_CONNECTION_SOCKS_PROXY_IMPL_H
+
+#include "DHTConnectionImpl.h"
+
+#include <memory>
+
+namespace aria2 {
+
+class SocketCore;
+
+class DHTConnectionSocksProxyImpl : public DHTConnectionImpl {
+private:
+  std::unique_ptr<SocketCore> proxySocket_;
+  int family_;
+  std::string bndAddr_;
+  uint16_t bndPort_;
+
+public:
+  DHTConnectionSocksProxyImpl(int family);
+
+  virtual ~DHTConnectionSocksProxyImpl();
+
+  // Connect to SOCKS5 server to start UDP proxy.
+  // Leave user and passwd empty to indicate no authentication.
+  // Leave listen host and port empty / 0 to indicate no receiving from proxy.
+  bool startProxy(const std::string& host, uint16_t port,
+                  const std::string& user, const std::string& passwd,
+                  const std::string& listenHost, uint16_t listenPort);
+
+  virtual ssize_t receiveMessage(unsigned char* data, size_t len,
+                                 std::string& host,
+                                 uint16_t& port) CXX11_OVERRIDE;
+
+  virtual ssize_t sendMessage(const unsigned char* data, size_t len,
+                              const std::string& host,
+                              uint16_t port) CXX11_OVERRIDE;
+};
+
+} // namespace aria2
+
+#endif // D_DHT_CONNECTION_SOCKS_PROXY_IMPL_H

--- a/src/DHTSetup.cc
+++ b/src/DHTSetup.cc
@@ -141,15 +141,23 @@ DHTSetup::setup(DownloadEngine* e, int family)
     A2_LOG_DEBUG(fmt("Initialized local node ID=%s",
                      util::toHex(localNode->getID(), DHT_ID_LENGTH).c_str()));
     {
-      if (!connection->startProxy("127.0.0.1", 8000, "", "",
+      const std::string& user =
+          e->getOption()->get(PREF_BT_UDP_SOCKS_PROXY_USER);
+      const std::string& passwd =
+          e->getOption()->get(PREF_BT_UDP_SOCKS_PROXY_PASSWD);
+      uri::UriStruct us;
+      uri::parse(us, e->getOption()->get(PREF_BT_UDP_SOCKS_PROXY));
+      const std::string& host = us.host;
+      uint16_t port = us.port;
+      if (!connection->startProxy(host, port, user, passwd,
                                   localNode->getIPAddress(),
                                   localNode->getPort())) {
         throw DL_ABORT_EX("Error occurred while connecting to SOCKS5 relay "
                           "server for UDP proxy for DHT and UDP trackers");
       }
+      A2_LOG_DEBUG(fmt("Connected to SOCKS5 relay server %s:%u for UDP proxy",
+                       host, port));
     }
-    A2_LOG_DEBUG(fmt("Connected to SOCKS5 relay server %s:%u for UDP proxy",
-                     "127.0.0.1", 8000));
     auto tracker = std::make_shared<DHTMessageTracker>();
     auto routingTable = make_unique<DHTRoutingTable>(localNode);
     auto factory = make_unique<DHTMessageFactoryImpl>(family);

--- a/src/FeatureConfig.cc
+++ b/src/FeatureConfig.cc
@@ -88,6 +88,9 @@ uint16_t getDefaultPort(const std::string& protocol)
   else if (protocol == "sftp") {
     return 22;
   }
+  else if (protocol == "socks") {
+    return 1080;
+  }
   else {
     return 0;
   }

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -503,6 +503,7 @@ SRCS += \
 	DHTBucketTree.cc DHTBucketTree.h\
 	DHTConnection.h\
 	DHTConnectionImpl.cc DHTConnectionImpl.h\
+	DHTConnectionSocksProxyImpl.cc DHTConnectionSocksProxyImpl.h\
 	DHTConstants.h\
 	DHTEntryPointNameResolveCommand.cc DHTEntryPointNameResolveCommand.h\
 	DHTFindNodeMessage.cc DHTFindNodeMessage.h\

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1372,6 +1372,37 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
   {
+    OptionHandler* op(new SocksProxyOptionHandler(
+        PREF_BT_UDP_SOCKS_PROXY, TEXT_BT_UDP_SOCKS_PROXY, NO_DEFAULT_VALUE));
+    op->addTag(TAG_BITTORRENT);
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
+  {
+    OptionHandler* op(new DefaultOptionHandler(PREF_BT_UDP_SOCKS_PROXY_PASSWD,
+                                               TEXT_BT_UDP_SOCKS_PROXY_PASSWD,
+                                               NO_DEFAULT_VALUE));
+    op->addTag(TAG_BITTORRENT);
+    op->setEraseAfterParse(true);
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
+  {
+    OptionHandler* op(new DefaultOptionHandler(PREF_BT_UDP_SOCKS_PROXY_USER,
+                                               TEXT_BT_UDP_SOCKS_PROXY_USER,
+                                               NO_DEFAULT_VALUE));
+    op->addTag(TAG_BITTORRENT);
+    op->setEraseAfterParse(true);
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
+  {
     OptionHandler* op(new HttpProxyOptionHandler(PREF_ALL_PROXY, TEXT_ALL_PROXY,
                                                  NO_DEFAULT_VALUE));
     op->addTag(TAG_FTP);

--- a/src/OptionHandlerImpl.cc
+++ b/src/OptionHandlerImpl.cc
@@ -529,6 +529,48 @@ std::string HttpProxyOptionHandler::createPossibleValuesString() const
   return "[http://][USER:PASSWORD@]HOST[:PORT]";
 }
 
+SocksProxyOptionHandler::SocksProxyOptionHandler(
+    PrefPtr pref, const char* description, const std::string& defaultValue,
+    char shortName)
+    : AbstractOptionHandler(pref, description, defaultValue,
+                            OptionHandler::REQ_ARG, shortName),
+      proxyUserPref_(option::k2p(std::string(pref->k) + "-user")),
+      proxyPasswdPref_(option::k2p(std::string(pref->k) + "-passwd"))
+{
+}
+
+SocksProxyOptionHandler::~SocksProxyOptionHandler() = default;
+
+void SocksProxyOptionHandler::parseArg(Option& option,
+                                       const std::string& optarg) const
+{
+  if (optarg.empty()) {
+    option.put(pref_, optarg);
+  }
+  else {
+    std::string uri;
+    if (util::startsWith(optarg, "socks://") ||
+        util::startsWith(optarg, "socks5://")) {
+      uri = optarg;
+    }
+    else {
+      uri = "socks://";
+      uri += optarg;
+    }
+    uri::UriStruct us;
+    if (!uri::parse(us, uri)) {
+      throw DL_ABORT_EX(_("unrecognized proxy format"));
+    }
+    us.protocol = "socks";
+    option.put(pref_, uri::construct(us));
+  }
+}
+
+std::string SocksProxyOptionHandler::createPossibleValuesString() const
+{
+  return "[socks[5]://][USER:PASSWORD@]HOST[:PORT]";
+}
+
 LocalFilePathOptionHandler::LocalFilePathOptionHandler(
     PrefPtr pref, const char* description, const std::string& defaultValue,
     bool acceptStdin, char shortName, bool mustExist,

--- a/src/OptionHandlerImpl.h
+++ b/src/OptionHandlerImpl.h
@@ -230,6 +230,20 @@ public:
   virtual std::string createPossibleValuesString() const CXX11_OVERRIDE;
 };
 
+class SocksProxyOptionHandler : public AbstractOptionHandler {
+private:
+  PrefPtr proxyUserPref_;
+  PrefPtr proxyPasswdPref_;
+
+public:
+  SocksProxyOptionHandler(PrefPtr pref, const char* description,
+                          const std::string& defaultValue, char shortName = 0);
+  virtual ~SocksProxyOptionHandler();
+  virtual void parseArg(Option& option,
+                        const std::string& optarg) const CXX11_OVERRIDE;
+  virtual std::string createPossibleValuesString() const CXX11_OVERRIDE;
+};
+
 class LocalFilePathOptionHandler : public AbstractOptionHandler {
 private:
   std::string possibleValuesString_;

--- a/src/option_processing.cc
+++ b/src/option_processing.cc
@@ -263,6 +263,7 @@ error_code::Value option_processing(Option& op, bool standalone,
     overrideWithEnv(*confOption, oparser, PREF_HTTP_PROXY, "http_proxy");
     overrideWithEnv(*confOption, oparser, PREF_HTTPS_PROXY, "https_proxy");
     overrideWithEnv(*confOption, oparser, PREF_FTP_PROXY, "ftp_proxy");
+    overrideWithEnv(*confOption, oparser, PREF_BT_UDP_SOCKS_PROXY, "bt_udp_sokcs_proxy");
     overrideWithEnv(*confOption, oparser, PREF_ALL_PROXY, "all_proxy");
     overrideWithEnv(*confOption, oparser, PREF_NO_PROXY, "no_proxy");
     if (!standalone) {

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -437,6 +437,7 @@ PrefPtr PREF_HTTP_PROXY = makePref("http-proxy");
 PrefPtr PREF_HTTPS_PROXY = makePref("https-proxy");
 PrefPtr PREF_FTP_PROXY = makePref("ftp-proxy");
 PrefPtr PREF_ALL_PROXY = makePref("all-proxy");
+PrefPtr PREF_BT_UDP_SOCKS_PROXY = makePref("bt-udp-socks-proxy");
 // values: comma separated hostname or domain
 PrefPtr PREF_NO_PROXY = makePref("no-proxy");
 // values: get | tunnel
@@ -447,6 +448,8 @@ PrefPtr PREF_HTTPS_PROXY_USER = makePref("https-proxy-user");
 PrefPtr PREF_HTTPS_PROXY_PASSWD = makePref("https-proxy-passwd");
 PrefPtr PREF_FTP_PROXY_USER = makePref("ftp-proxy-user");
 PrefPtr PREF_FTP_PROXY_PASSWD = makePref("ftp-proxy-passwd");
+PrefPtr PREF_BT_UDP_SOCKS_PROXY_USER = makePref("bt-udp-socks-proxy-user");
+PrefPtr PREF_BT_UDP_SOCKS_PROXY_PASSWD = makePref("bt-udp-socks-proxy-passwd");
 PrefPtr PREF_ALL_PROXY_USER = makePref("all-proxy-user");
 PrefPtr PREF_ALL_PROXY_PASSWD = makePref("all-proxy-passwd");
 

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -388,6 +388,7 @@ extern PrefPtr PREF_CONTENT_DISPOSITION_DEFAULT_UTF8;
 extern PrefPtr PREF_HTTP_PROXY;
 extern PrefPtr PREF_HTTPS_PROXY;
 extern PrefPtr PREF_FTP_PROXY;
+extern PrefPtr PREF_BT_UDP_SOCKS_PROXY;
 extern PrefPtr PREF_ALL_PROXY;
 // values: comma separated hostname or domain
 extern PrefPtr PREF_NO_PROXY;
@@ -399,6 +400,8 @@ extern PrefPtr PREF_HTTPS_PROXY_USER;
 extern PrefPtr PREF_HTTPS_PROXY_PASSWD;
 extern PrefPtr PREF_FTP_PROXY_USER;
 extern PrefPtr PREF_FTP_PROXY_PASSWD;
+extern PrefPtr PREF_BT_UDP_SOCKS_PROXY_USER;
+extern PrefPtr PREF_BT_UDP_SOCKS_PROXY_PASSWD;
 extern PrefPtr PREF_ALL_PROXY_USER;
 extern PrefPtr PREF_ALL_PROXY_PASSWD;
 

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -83,6 +83,9 @@
     "                              previously defined proxy, use \"\".\n" \
     "                              See also the --all-proxy option.\n"     \
     "                              This affects all ftp downloads.")
+#define TEXT_BT_UDP_SOCKS_PROXY                                                 \
+  _(" --bt-udp-socks-proxy=PROXY   Use a SOCKS5 proxy server for UDP in BitTorrent.\n"\
+    "                              This affects DHT and connecting UDP trackers in BitTorrent.")
 #define TEXT_ALL_PROXY                                                  \
   _(" --all-proxy=PROXY            Use a proxy server for all protocols. To override\n" \
     "                              a previously defined proxy, use \"\".\n" \
@@ -690,6 +693,10 @@
   _(" --ftp-proxy-user=USER        Set user for --ftp-proxy.")
 #define TEXT_FTP_PROXY_PASSWD                                           \
   _(" --ftp-proxy-passwd=PASSWD    Set password for --ftp-proxy.")
+#define TEXT_BT_UDP_SOCKS_PROXY_USER                                    \
+  _(" --bt-udp-socks-proxy-user=USER Set user for --http-proxy.")
+#define TEXT_BT_UDP_SOCKS_PROXY_PASSWD                                  \
+  _(" --bt-udp-socks-proxy-passwd=PASSWD Set password for --http-proxy.")
 #define TEXT_REMOVE_CONTROL_FILE                \
   _(" --remove-control-file[=true|false] Remove control file before download. Using\n" \
     "                              with --allow-overwrite=true, download always\n" \

--- a/test/DHTConnectionSocksProxyImplTest.cc
+++ b/test/DHTConnectionSocksProxyImplTest.cc
@@ -1,0 +1,82 @@
+#include "DHTConnectionSocksProxyImpl.h"
+
+#include <iostream>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "Exception.h"
+#include "SocketCore.h"
+#include "A2STR.h"
+
+namespace aria2 {
+
+class DHTConnectionSocksProxyImplTest : public CppUnit::TestFixture {
+
+  CPPUNIT_TEST_SUITE(DHTConnectionSocksProxyImplTest);
+  CPPUNIT_TEST(testWriteAndReadData);
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+
+  void tearDown() {}
+
+  void testWriteAndReadData();
+};
+
+CPPUNIT_TEST_SUITE_REGISTRATION(DHTConnectionSocksProxyImplTest);
+
+void DHTConnectionSocksProxyImplTest::testWriteAndReadData()
+{
+  try {
+    DHTConnectionSocksProxyImpl con1(AF_INET);
+    uint16_t con1port = 0;
+    CPPUNIT_ASSERT(con1.bind(con1port, "127.0.0.1"));
+
+    DHTConnectionImpl con2(AF_INET);
+    uint16_t con2port = 0;
+    CPPUNIT_ASSERT(con2.bind(con2port, "127.0.0.1"));
+
+    // TODO: Requires a SOCKS5 proxy server for tests
+    return;
+    CPPUNIT_ASSERT(
+        con1.startProxy("localhost", 10801, "", "", "127.0.0.1", con1port));
+
+    std::string message1 = "hello world.";
+    con1.sendMessage(reinterpret_cast<const unsigned char*>(message1.c_str()),
+                     message1.size(), "127.0.0.1", con2port);
+
+    unsigned char readbuffer[100];
+    std::string remoteHost;
+    uint16_t remotePort;
+    {
+      while (!con2.getSocket()->isReadable(0))
+        ;
+      ssize_t rlength = con2.receiveMessage(readbuffer, sizeof(readbuffer),
+                                            remoteHost, remotePort);
+      CPPUNIT_ASSERT_EQUAL((ssize_t)message1.size(), rlength);
+      CPPUNIT_ASSERT_EQUAL(message1,
+                           std::string(&readbuffer[0], &readbuffer[rlength]));
+    }
+
+    std::string message2 = "hello world too.";
+    con2.sendMessage(reinterpret_cast<const unsigned char*>(message2.c_str()),
+                     message2.size(), remoteHost, remotePort);
+
+    {
+      std::string remoteHost;
+      uint16_t remotePort;
+      while (!con1.getSocket()->isReadable(0))
+        ;
+      ssize_t rlength = con1.receiveMessage(readbuffer, sizeof(readbuffer),
+                                            remoteHost, remotePort);
+      CPPUNIT_ASSERT_EQUAL((ssize_t)message2.size(), rlength);
+      CPPUNIT_ASSERT_EQUAL(message2,
+                           std::string(&readbuffer[0], &readbuffer[rlength]));
+    }
+  }
+  catch (Exception& e) {
+    CPPUNIT_FAIL(e.stackTrace());
+  }
+}
+
+} // namespace aria2

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -170,6 +170,7 @@ aria2c_SOURCES += BtAllowedFastMessageTest.cc\
 	DHTMessageTrackerEntryTest.cc\
 	DHTMessageTrackerTest.cc\
 	DHTConnectionImplTest.cc\
+	DHTConnectionSocksProxyImplTest.cc\
 	DHTPingMessageTest.cc\
 	DHTPingReplyMessageTest.cc\
 	DHTFindNodeMessageTest.cc\


### PR DESCRIPTION
The PR adds a new class `DHTConnectionSocksProxyImpl` which inherients `DHTConnectionImpl`, and uses it in `DHTSetup`, to provide SOCKS5 proxy support for UDP connections in BT, including UDP tracker and DHT connections (as `DHTConnectionImpl` is used by both DHT and UDP trackers despite the name).

The PR also adds options `bt-udp-socks-proxy`, `bt-udp-socks-proxy-user`, and `bt-udp-socks-proxy-pass` to configure the proxy. When no proxy is set, the app fallbacks to use `DHTConnectionImpl` that is without proxy. Parsing and cleaning of `bt-udp-socks-proxy` uses newly added `SocksProxyOptionHandler`, which works like `HttpProxyOptionHandler`. These UDP proxy options, though put aside other proxy options, wont be overrided by `all-proxy`.

A test has been included in the PR. However, as the test requires a SOCKS5 proxy server, currently the test is surpressed by early returning. I would like to suggest adding a SOCKS5 proxy server as fixtures via adding a 3rd party library or asking developers to start one in advance by such as [GOST](https://v2.gost.run/en/socks/).

Ref: #470 and part of #153