### PR TITLE
Workaround for crash on EX_INVALID_RANGE_HEADER

### DIFF
--- a/src/HttpRequest.cc
+++ b/src/HttpRequest.cc
@@ -53,6 +53,7 @@
 #include "Request.h"
 #include "DownloadHandlerConstants.h"
 #include "MessageDigest.h"
+#include "LogFactory.h"
 
 namespace aria2 {
 
@@ -124,7 +125,7 @@ bool HttpRequest::isRangeSatisfied(const Range& range) const
     return true;
   }
   return getStartByte() == range.startByte &&
-         (getEndByte() == 0 || getEndByte() == range.endByte) &&
+         (getEndByte() == 0 || getEndByte() <= range.endByte) &&
          (fileEntry_->getLength() == 0 ||
           fileEntry_->getLength() == range.entityLength);
 }

--- a/src/message.h
+++ b/src/message.h
@@ -211,6 +211,7 @@
 #define MSG_REMOVING_UNSELECTED_FILE _("GID#%s - Removing unselected file.")
 #define MSG_FILE_REMOVED _("File %s removed.")
 #define MSG_FILE_COULD_NOT_REMOVED _("File %s could not be removed.")
+#define MSG_STRANGE_RANGE_HEADER "CUID#%" PRId64 " Strange range header. Request: %" PRId64 "-%" PRId64 "/%" PRId64 ", Response: %" PRId64 "-%" PRId64 "/%" PRId64 ""
 
 #define EX_TIME_OUT _("Timeout.")
 #define EX_INVALID_CHUNK_SIZE _("Invalid chunk size.")


### PR DESCRIPTION
Seems to save the download in some cases

What bugs me is that the patched version does not issue a warning.
Looks like there is a race condition somewhere.
I have put logs in my comment to https://github.com/aria2/aria2/issues/1344