### PR TITLE
Increase ByteArrayDiskWriter maximum size

### DIFF
--- a/src/ByteArrayDiskWriter.h
+++ b/src/ByteArrayDiskWriter.h
@@ -49,7 +49,7 @@ private:
   void clear();
 
 public:
-  ByteArrayDiskWriter(size_t maxLength = 5_m);
+  ByteArrayDiskWriter(size_t maxLength = 15_m);
   virtual ~ByteArrayDiskWriter();
 
   virtual void initAndOpenFile(int64_t totalLength = 0) CXX11_OVERRIDE;


### PR DESCRIPTION
Fixes #1892

Previous limit of 5MB has been set 10 years ago. Meanwhile average computer has at least 3x more memory, see https://techtalk.pcmatic.com/research-charts-memory/. Therefore, let makes this top limit evolves accordingly: up to 15MB.