### PR TITLE
add no-want-digest-header option

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -557,6 +557,10 @@ HTTP Specific Options
   Use HEAD method for the first request to the HTTP server.
   Default: ``false``
 
+.. option:: --no-want-digest-header [true|false]
+
+  Whether to disable Want-Digest header when doing requests.
+  Default: ``false``
 
 .. option:: -U, --user-agent=<USER_AGENT>
 

--- a/src/HttpRequestCommand.cc
+++ b/src/HttpRequestCommand.cc
@@ -99,6 +99,8 @@ createHttpRequest(const std::shared_ptr<Request>& req,
   httpRequest->setOption(option.get());
   httpRequest->setProxyRequest(proxyRequest);
   httpRequest->setAcceptMetalink(rg->getDownloadContext()->getAcceptMetalink());
+  httpRequest->setNoWantDigest(option->getAsBool(PREF_NO_WANT_DIGEST_HEADER));
+
   if (option->getAsBool(PREF_HTTP_ACCEPT_GZIP)) {
     httpRequest->enableAcceptGZip();
   }

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -1206,6 +1206,15 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
   {
+    OptionHandler* op(new BooleanOptionHandler(
+        PREF_NO_WANT_DIGEST_HEADER, TEXT_NO_WANT_DIGEST_HEADER, A2_V_FALSE, OptionHandler::OPT_ARG));
+    op->addTag(TAG_HTTP);
+    op->setInitialOption(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
+  {
     OptionHandler* op(new DefaultOptionHandler(
         PREF_USER_AGENT, TEXT_USER_AGENT, "aria2/" PACKAGE_VERSION, A2STR::NIL,
         OptionHandler::REQ_ARG, 'U'));

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -429,7 +429,8 @@ PrefPtr PREF_HTTP_ACCEPT_GZIP = makePref("http-accept-gzip");
 // value: true | false
 PrefPtr PREF_CONTENT_DISPOSITION_DEFAULT_UTF8 =
     makePref("content-disposition-default-utf8");
-
+// value: true | false
+PrefPtr PREF_NO_WANT_DIGEST_HEADER = makePref("no-want-digest-header");
 /**
  * Proxy related preferences
  */

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -381,6 +381,8 @@ extern PrefPtr PREF_HTTP_NO_CACHE;
 extern PrefPtr PREF_HTTP_ACCEPT_GZIP;
 // value: true | false
 extern PrefPtr PREF_CONTENT_DISPOSITION_DEFAULT_UTF8;
+// value: true | false
+extern PrefPtr PREF_NO_WANT_DIGEST_HEADER;
 
 /**;
  * Proxy related preferences

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -539,6 +539,9 @@
 #define TEXT_USE_HEAD                                                   \
   _(" --use-head[=true|false]      Use HEAD method for the first request to the HTTP\n" \
     "                              server.")
+#define TEXT_NO_WANT_DIGEST_HEADER                                      \
+  _(" --no-want-digest-header[=true|false] Whether to disable Want-Digest header \n" \
+    "                              when doing requests.")
 #define TEXT_CONTENT_DISPOSITION_DEFAULT_UTF8                          \
   _(" --content-disposition-default-utf8[=true|false] Handle quoted string in\n" \
     "                              Content-Disposition header as UTF-8 instead of\n" \


### PR DESCRIPTION
This fixes #1136 
Since there's already a `setNoWantDigest` function for http request, adding this is quite straightforward.

## doc

new http options: `--no-want-digest-header` (the naming probably could improve)
help:
`src/aria2c --help='#http'`
![image](https://user-images.githubusercontent.com/7122156/161376335-473a52d4-aa33-4903-bfec-8ae144de8449.png)

manpage:
![image](https://user-images.githubusercontent.com/7122156/161376380-3ffc3421-ef67-4d9b-b7f0-31f0b9a59ca0.png)


## test

testing with `nc -lvnp 9001`:

**default**
![image](https://user-images.githubusercontent.com/7122156/161376508-edf180a9-b097-4394-bcf4-4dda56836c5d.png)

**--no-want-digest-header**
![image](https://user-images.githubusercontent.com/7122156/161376540-2b0e223b-baa8-43ef-97c6-787389a28ea1.png)
