### PR TITLE
fix sphinx installation comamnd for macos installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ compile
 main.log
 main.trs
 test-suite.log
+build-release

--- a/makerelease-osx.mk
+++ b/makerelease-osx.mk
@@ -103,7 +103,7 @@ LTO_FLAGS = -flto -ffunction-sections -fdata-sections
 # Dependency versions
 zlib_version = 1.2.11
 zlib_hash = c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
-zlib_url = http://zlib.net/zlib-$(zlib_version).tar.gz
+zlib_url = http://zlib.net/fossils/zlib-$(zlib_version).tar.gz
 
 expat_version = 2.2.8
 expat_hash = bd507cba42716ca9afe46dd3687fb0d46c09347517beb9770f53a435d2c67ea0

--- a/makerelease-osx.mk
+++ b/makerelease-osx.mk
@@ -29,7 +29,7 @@
 #  - $ virtualenv .
 #  - $ . bin/activate
 #  - $ pip install -U sphinx
-#  - $ ln -s ../makerelease-os.mk Makefile
+#  - $ ln -s ../makerelease-osx.mk Makefile
 #  - $ make
 #
 # If you haven't checkout out a release tag, you need to specify NON_RELEASE.

--- a/makerelease-osx.mk
+++ b/makerelease-osx.mk
@@ -28,7 +28,7 @@
 #  - $ cd build-release
 #  - $ virtualenv .
 #  - $ . bin/activate
-#  - $ pip install sphinx-build
+#  - $ pip install -U sphinx
 #  - $ ln -s ../makerelease-os.mk Makefile
 #  - $ make
 #


### PR DESCRIPTION
`pip install sphinx-build` results in 
```
ERROR: Could not find a version that satisfies the requirement sphinx-build (from versions: none)
ERROR: No matching distribution found for sphinx-build
```

after checking the docs https://www.sphinx-doc.org/en/master/usage/installation.html

i've decided to create a PR with the correct command and add the suggested build forder to gitignore
