### PR TITLE
Make releases with docker

### DIFF
--- a/Dockerfile.android
+++ b/Dockerfile.android
@@ -40,7 +40,7 @@ RUN curl -L -O https://dl.google.com/android/repository/android-ndk-$NDK_VERSION
    rm android-ndk-$NDK_VERSION-linux.zip
 
 # aria2 version
-ENV ARIA2_VERSION master
+ARG ARIA2_VERSION=master
 
 # Library versions
 ENV OPENSSL_VERSION=1.1.1w
@@ -122,7 +122,7 @@ RUN ./configure \
 
 # Build aria2
 WORKDIR /root/build
-RUN git clone https://github.com/aria2/aria2 -b $ARIA2_VERSION --depth 1
+RUN git clone -b $ARIA2_VERSION --depth 1 https://github.com/aria2/aria2
 
 WORKDIR /root/build/aria2
 RUN autoreconf -i && \

--- a/Dockerfile.mingw
+++ b/Dockerfile.mingw
@@ -16,7 +16,7 @@ FROM ubuntu:22.04
 MAINTAINER Tatsuhiro Tsujikawa
 
 # Change HOST to x86_64-w64-mingw32 to build 64-bit binary
-ENV HOST i686-w64-mingw32
+ARG HOST=i686-w64-mingw32
 
 # It would be better to use nearest ubuntu archive mirror for faster
 # downloads.
@@ -107,7 +107,11 @@ RUN tar xf libssh2-1.11.0.tar.bz2 && \
         --with-wincng \
         LIBS="-lws2_32" && \
     make install
-ADD https://api.github.com/repos/aria2/aria2/git/refs/heads/master version.json
-RUN git clone https://github.com/aria2/aria2 && \
+
+ARG ARIA2_VERSION=master
+ARG ARIA2_REF=refs/heads/master
+
+ADD https://api.github.com/repos/aria2/aria2/git/$ARIA2_REF version.json
+RUN git clone -b $ARIA2_VERSION --depth 1 https://github.com/aria2/aria2 && \
     cd aria2 && autoreconf -i && ./mingw-config && make && \
     $HOST-strip src/aria2c.exe

--- a/android-release
+++ b/android-release
@@ -31,14 +31,6 @@
 # version.  If you delete this exception statement from all source
 # files in the program, then also delete it here.
 
-if [ -z "$NDK" ]; then
-    echo 'No $NDK specified.'
-    exit 1
-fi
-
-TOOLCHAIN=$NDK/toolchains/llvm/prebuilt/linux-x86_64
-PATH=$TOOLCHAIN/bin:$PATH
-
 # cd to the directory where this script exists.
 cd $(dirname $0)
 . ./script-helper
@@ -51,9 +43,8 @@ if [ -z "$VERSION" ]; then
 fi
 
 DIST_DIR=aria2-$VERSION-aarch64-linux-android-build1
-aarch64-linux-android-strip src/aria2c
 mkdir $DIST_DIR
 cp AUTHORS COPYING ChangeLog LICENSE.OpenSSL NEWS README.html README.android \
-    src/aria2c $DIST_DIR
+    android-out/aria2c $DIST_DIR
 zip -9 -r $DIST_DIR.zip $DIST_DIR
 rm -rf $DIST_DIR

--- a/makerelease
+++ b/makerelease
@@ -1,14 +1,5 @@
 #!/bin/sh -e
 
-if [ -z "$ANDROID_HOME" ]; then
-    echo 'No $ANDROID_HOME specified.'
-    exit 1
-fi
-if [ -z "$NDK" ]; then
-    echo 'No $NDK specified.'
-    exit 1
-fi
-
 VERSION=$1
 PREV_VERSION=$2
 
@@ -21,26 +12,45 @@ autoreconf -i
     make dist-bzip2 && make dist-gzip && make dist-xz || echo "error"
 make distclean
 
+release_mingw()
+{
+    export HOST=$1
+    export LABEL=$2
+
+    mkdir -p mingw-out
+
+    docker build \
+	   --build-arg HOST=$HOST \
+	   --build-arg ARIA2_VERSION=$VERSION \
+	   --build-arg ARIA2_REF=refs/tags/release-$VERSION \
+	   -t aria2-mingw-$HOST - < Dockerfile.mingw
+
+    docker run --rm -it -v $PWD/mingw-out:/out aria2-mingw-$HOST \
+	   cp /aria2/src/aria2c.exe /out
+
+    ./mingw-release
+
+    rm -rf mingw-out
+}
+
 # mingw 32bit
-export HOST=i686-w64-mingw32
-export LABEL=win-32bit
-./mingw-config
-make -j8
-./mingw-release
-make distclean
+release_mingw i686-w64-mingw32 win-32bit
 
 # mingw 64bit
-export HOST=x86_64-w64-mingw32
-export LABEL=win-64bit
-./mingw-config
-make -j8
-./mingw-release
-make distclean
+release_mingw x86_64-w64-mingw32 win-64bit
 
 # android
-./android-config
-make -j8
+mkdir -p android-out
+
+docker build \
+       --build-arg ARIA2_VERSION=$VERSION \
+       -t aria2-android - < Dockerfile.android
+
+docker run --rm -it -v $PWD/android-out:/out aria2-android \
+       cp /root/build/aria2/src/aria2c /out
+
 ./android-release
-make distclean
+
+rm -rf android-out
 
 # OSX builds are created separately using makerelease-osx.mk

--- a/mingw-release
+++ b/mingw-release
@@ -48,9 +48,8 @@ fi
 
 DIST_DIR=aria2-${VERSION}-${LABEL}-build${BUILD_VER}
 
-/usr/bin/$HOST-strip src/aria2c.exe
 mkdir $DIST_DIR
 cp AUTHORS COPYING ChangeLog LICENSE.OpenSSL NEWS README.html README.mingw \
-    src/aria2c.exe $DIST_DIR
+    mingw-out/aria2c.exe $DIST_DIR
 zip -9 -r $DIST_DIR.zip $DIST_DIR
 rm -rf $DIST_DIR


### PR DESCRIPTION
This is slightly different from the current procedure because now android and mingw binaries are built from source code fetched from the remote repository.