### PR TITLE
Dockerfile.mingw: Downgrade c-ares to 1.19.1

### DIFF
--- a/Dockerfile.mingw
+++ b/Dockerfile.mingw
@@ -32,7 +32,7 @@ RUN curl -L -O https://gmplib.org/download/gmp/gmp-6.3.0.tar.xz && \
     curl -L -O https://github.com/libexpat/libexpat/releases/download/R_2_5_0/expat-2.5.0.tar.bz2 && \
     curl -L -O https://www.sqlite.org/2023/sqlite-autoconf-3430100.tar.gz && \
     curl -L -O https://www.zlib.net/zlib-1.3.tar.gz && \
-    curl -L -O https://c-ares.org/download/c-ares-1.21.0.tar.gz && \
+    curl -L -O https://c-ares.org/download/c-ares-1.19.1.tar.gz && \
     curl -L -O https://libssh2.org/download/libssh2-1.11.0.tar.bz2
 
 RUN tar xf gmp-6.3.0.tar.xz && \
@@ -81,8 +81,8 @@ RUN tar xf zlib-1.3.tar.gz && \
         --static && \
     make -j$(nproc) install
 
-RUN tar xf c-ares-1.21.0.tar.gz && \
-    cd c-ares-1.21.0 && \
+RUN tar xf c-ares-1.19.1.tar.gz && \
+    cd c-ares-1.19.1 && \
     ./configure \
         --disable-shared \
         --enable-static \


### PR DESCRIPTION
Downgrade c-ares to 1.19.1 in Dockerfile.mingw because it does not build on x86_64 host.