### PR TITLE
Add workaround for noncompliant Content-Disposition headers.

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -1245,6 +1245,16 @@ ssize_t parse_content_disposition(char* dest, size_t destlen,
   *charsetp = nullptr;
   *charsetlenp = 0;
 
+  /*
+   * Ignore trailing ';' in Content-Disposition header; this is not
+   * compliant with RFC 6266, but many servers send it anyway (e.g. CloudFront)
+   */
+  if (len > 0 && *eop == ';') {
+    A2_LOG_INFO("Non-compliant Content-Disposition header (trailing ';') - "
+                "will ignore it");
+    eop--;
+  }
+
   for (; p != eop; ++p) {
     switch (state) {
     case CD_BEFORE_DISPOSITION_TYPE:


### PR DESCRIPTION
Despite it not being allowed by RFC 6266, many servers send `Content-Disposition` headers with a trailing `;`, including several major content distribution networks. Add a check for a trailing semicolon in `parse_content_disposition()` which will log a message at INFO level for each offending URL and ignore the `;`.

Fixes #1118.

This probably isn't the best way to handle this, but the state machine code inside `parse_content_disposition()` is rather complicated so I elected to mess with it as little as possible. Code just checks if `len > 0` and the final character is `;`, then prints a message at INFO level and decrements `eop` by one so the remaining code will ignore it (credit to @mgrinzPlayer for the idea).

Happy to come at this from another direction if you'd prefer 😄