### PR TITLE
fix tracker selection

### DIFF
--- a/src/AnnounceList.cc
+++ b/src/AnnounceList.cc
@@ -109,10 +109,15 @@ void AnnounceList::announceSuccess()
   if (currentTrackerInitialized_) {
     (*currentTier_)->nextEvent();
     auto url = *currentTracker_;
-    (*currentTier_)->urls.erase(currentTracker_);
+    currentTracker_ = (*currentTier_)->urls.erase(currentTracker_);
     (*currentTier_)->urls.push_front(std::move(url));
-    currentTier_ = std::begin(tiers_);
-    currentTracker_ = std::begin((*currentTier_)->urls);
+    if (currentTracker_ == std::end((*currentTier_)->urls)) {
+      ++currentTier_;
+      if (currentTier_ == std::end(tiers_)) {
+        currentTier_ = std::begin(tiers_);
+      }
+      currentTracker_ = std::begin((*currentTier_)->urls);
+    }
   }
 }
 

--- a/src/AnnounceList.h
+++ b/src/AnnounceList.h
@@ -95,8 +95,9 @@ public:
   /**
    * Removes current announce URL from its group and inserts it before the
    * first element of the group.
-   * The internal announce group pointer points to the first element of the
-   * first group after this call.
+   * The internal announce group pointer points to the next element.
+   * If the current URL is the last element of its group, then the first
+   * element of the next group is pointed.
    */
   void announceSuccess();
 


### PR DESCRIPTION
After a successful tracker announcement, the current url is moved to the front of the group and is reset to the first url of the first group. This will cause aria2 to use those few trackers repeatedly. This issue is reported [here](https://github.com/aria2/aria2/issues/1101).

This patch still moves those successful urls to the front of the group. However, it will use the next tracker in the group, so that every tracker has a chance to be used.