### PR TITLE
Add option for control file storage path: --control-file-base-directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,5 @@ compile
 main.log
 main.trs
 test-suite.log
+.idea/
+build/

--- a/src/DefaultBtProgressInfoFile.cc
+++ b/src/DefaultBtProgressInfoFile.cc
@@ -68,9 +68,17 @@ namespace aria2 {
 
 namespace {
 std::string createFilename(const std::shared_ptr<DownloadContext>& dctx,
-                           const std::string& suffix)
+                           const std::string& suffix,
+                           const std::string& baseDirectory)
 {
   std::string t = dctx->getBasePath();
+  if (!baseDirectory.empty()) {
+    t = baseDirectory;
+    if (baseDirectory.back() != *File::getPathSeparators()) {
+      t += File::getPathSeparators();
+    }
+    t += File(dctx->getBasePath()).getBasename();
+  }
   t += suffix;
   return t;
 }
@@ -82,7 +90,8 @@ DefaultBtProgressInfoFile::DefaultBtProgressInfoFile(
     : dctx_(dctx),
       pieceStorage_(pieceStorage),
       option_(option),
-      filename_(createFilename(dctx_, getSuffix()))
+      filename_(createFilename(dctx_, getSuffix(),
+                               option->get(PREF_CONTROL_FILE_BASE_DIRECTORY)))
 {
 }
 
@@ -90,7 +99,7 @@ DefaultBtProgressInfoFile::~DefaultBtProgressInfoFile() = default;
 
 void DefaultBtProgressInfoFile::updateFilename()
 {
-  filename_ = createFilename(dctx_, getSuffix());
+  filename_ = createFilename(dctx_, getSuffix(), "");
 }
 
 bool DefaultBtProgressInfoFile::isTorrentDownload()

--- a/src/DefaultBtProgressInfoFile.h
+++ b/src/DefaultBtProgressInfoFile.h
@@ -36,6 +36,7 @@
 #define D_DEFAULT_BT_PROGRESS_INFO_FILE_H
 
 #include "BtProgressInfoFile.h"
+#include "prefs.h"
 
 #include <memory>
 

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -652,6 +652,14 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
   }
   {
     OptionHandler* op(new LocalFilePathOptionHandler(
+        PREF_CONTROL_FILE_BASE_DIRECTORY, CONTROL_FILE_BASE_DIRECTORY, NO_DEFAULT_VALUE,
+        /* acceptStdin = */ false, 0, /* mustExist = */ false));
+    op->addTag(TAG_ADVANCED);
+    op->setChangeGlobalOption(true);
+    handlers.push_back(op);
+  }
+  {
+    OptionHandler* op(new LocalFilePathOptionHandler(
         PREF_SAVE_SESSION, TEXT_SAVE_SESSION, NO_DEFAULT_VALUE,
         /* acceptStdin = */ false, 0, /* mustExist = */ false));
     op->addTag(TAG_ADVANCED);

--- a/src/prefs.cc
+++ b/src/prefs.cc
@@ -306,6 +306,8 @@ PrefPtr PREF_DISABLE_IPV6 = makePref("disable-ipv6");
 PrefPtr PREF_HUMAN_READABLE = makePref("human-readable");
 // value: true | false
 PrefPtr PREF_REMOVE_CONTROL_FILE = makePref("remove-control-file");
+// value: string
+PrefPtr PREF_CONTROL_FILE_BASE_DIRECTORY = makePref("control-file-base-directory");
 // value: true | false
 PrefPtr PREF_ALWAYS_RESUME = makePref("always-resume");
 // value: 1*digit

--- a/src/prefs.h
+++ b/src/prefs.h
@@ -259,6 +259,8 @@ extern PrefPtr PREF_DISABLE_IPV6;
 extern PrefPtr PREF_HUMAN_READABLE;
 // value: true | false
 extern PrefPtr PREF_REMOVE_CONTROL_FILE;
+// value: a string
+extern PrefPtr PREF_CONTROL_FILE_BASE_DIRECTORY;
 // value: true | false
 extern PrefPtr PREF_ALWAYS_RESUME;
 // value: 1*digit

--- a/src/usage_text.h
+++ b/src/usage_text.h
@@ -698,6 +698,8 @@
     "                              with --allow-overwrite=true, download always\n" \
     "                              starts from scratch. This will be useful for\n" \
     "                              users behind proxy server which disables resume.")
+#define CONTROL_FILE_BASE_DIRECTORY                                           \
+  _(" --control-file-base-directory=DIR    The directory to store the control file.")
 #define TEXT_ALWAYS_RESUME                      \
   _(" --always-resume[=true|false] Always resume download. If true is given, aria2\n" \
     "                              always tries to resume download and if resume is\n" \


### PR DESCRIPTION
When downloading lists that contain a large number of small files, and we are using disk storage, we aim to avoid frequent file creation and deletion. Instead, we prefer to create control files in a different directory, such as /Volumes/ramdisk or /dev/shm.