### PR TITLE
Fix high CPU usage when sending unauthorized RPC response

### DIFF
--- a/src/HttpServerBodyCommand.cc
+++ b/src/HttpServerBodyCommand.cc
@@ -149,6 +149,7 @@ void HttpServerBodyCommand::addHttpServerResponseCommand(bool delayed)
   auto resp = make_unique<HttpServerResponseCommand>(getCuid(), httpServer_, e_,
                                                      socket_);
   if (delayed) {
+    e_->deleteSocketForWriteCheck(socket_, resp.get());
     e_->addCommand(
         make_unique<DelayedCommand>(getCuid(), e_, 1_s, std::move(resp), true));
     return;


### PR DESCRIPTION
Root Cause: DelayedCommand execute continuously without wait while HTTP response socket is writable for check at that time.

close: alexhua/Aria2-Explorer#63