### PR TITLE
Retry when requested range not satisfied

### DIFF
--- a/src/HttpResponse.cc
+++ b/src/HttpResponse.cc
@@ -78,7 +78,7 @@ void HttpResponse::validateResponse() const
       // compare the received range against the requested range
       auto responseRange = httpHeader_->getRange();
       if (!httpRequest_->isRangeSatisfied(responseRange)) {
-        throw DL_ABORT_EX2(
+        throw DL_RETRY_EX2(
             fmt(EX_INVALID_RANGE_HEADER, httpRequest_->getStartByte(),
                 httpRequest_->getEndByte(), httpRequest_->getEntityLength(),
                 responseRange.startByte, responseRange.endByte,


### PR DESCRIPTION
Regarding range-error aborts from https://github.com/aria2/aria2/issues/1344

I've run into such aborts a couple of times now, mostly when downloading 100GB+ files from CDNs.

In the cases I've observed, the partial-content responses that give incorrect range headers seem completely non-deterministic — retrying the same download several times, will result in different chunks range-aborting.

My *hypothesis* for what's going on in these cases (and perhaps many of the ones people are noticing in #1344), is that `aria2c` is talking to a load-balancer and/or doing DNS round-robin, such that each partial request is being directed to a different server backend; and the pool of backend nodes has a heterogenous mix of webserver versions or configurations — such that a minority of the nodes are bugged somehow. Each "roll of the dice" for a chunk can therefore result in talking to a bad server that gives you a bad Range response header.

But *why* it happens doesn't really matter; all that matters is that these cases *are* non-deterministic, and therefore will almost always be fixed by just retrying the request.

This PR simply makes aria2 retry, rather than abort, when `!(HttpRequest::isRangeSatisfied(...))`.

If the failure *is* deterministic, aria2 will eventually hit its retry limit and abort anyway. (I've yet to experience such a case; I expect it to be vanishingly rare compared to the non-deterministic case.)