### PR TITLE
c-ares: Avoid deprecated functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -503,18 +503,10 @@ fi
 
 have_libcares=no
 if test "x$with_libcares" = "xyes"; then
-  PKG_CHECK_MODULES([LIBCARES], [libcares >= 1.7.0], [have_libcares=yes],
+  PKG_CHECK_MODULES([LIBCARES], [libcares >= 1.16.0], [have_libcares=yes],
                     [have_libcares=no])
   if test "x$have_libcares" = "xyes"; then
     AC_DEFINE([HAVE_LIBCARES], [1], [Define to 1 if you have libcares.])
-    save_LIBS=$LIBS
-    save_CPPFLAGS=$CPPFLAGS
-    LIBS="$LIBCARES_LIBS $LIBS"
-    CPPFLAGS="$LIBCARES_CFLAGS $CPPFLAGS"
-    AC_CHECK_TYPES([ares_addr_node], [], [], [[#include <ares.h>]])
-    AC_CHECK_FUNCS([ares_set_servers])
-    LIBS=$save_LIBS
-    CPPFLAGS=$save_CPPFLAGS
 
     # -DCARES_STATICLIB is appended by pkg-config file libcares.pc
   else

--- a/src/AsyncNameResolver.h
+++ b/src/AsyncNameResolver.h
@@ -46,9 +46,14 @@
 
 namespace aria2 {
 
+struct AsyncNameResolverSocketEntry {
+  int fd;
+  int events;
+};
+
 class AsyncNameResolver {
   friend void callback(void* arg, int status, int timeouts,
-                       struct hostent* host);
+                       ares_addrinfo* result);
 
 public:
   enum STATUS {
@@ -59,6 +64,7 @@ public:
   };
 
 private:
+  std::vector<AsyncNameResolverSocketEntry> socks_;
   STATUS status_;
   int family_;
   ares_channel channel_;
@@ -68,12 +74,7 @@ private:
   std::string hostname_;
 
 public:
-  AsyncNameResolver(int family
-#ifdef HAVE_ARES_ADDR_NODE
-                    ,
-                    ares_addr_node* servers
-#endif // HAVE_ARES_ADDR_NODE
-  );
+  AsyncNameResolver(int family, const std::string& servers);
 
   ~AsyncNameResolver();
 
@@ -95,7 +96,7 @@ public:
   int getFamily() const { return family_; }
 #ifdef HAVE_LIBCARES
 
-  int getsock(sock_t* sockets) const;
+  const std::vector<AsyncNameResolverSocketEntry>& getsock() const;
 
   void process(ares_socket_t readfd, ares_socket_t writefd);
 
@@ -105,16 +106,10 @@ public:
 
   void setAddr(const std::string& addrString);
 
-  void reset();
-
   const std::string& getHostname() const { return hostname_; }
+
+  void handle_sock_state(int sock, int read, int write);
 };
-
-#ifdef HAVE_ARES_ADDR_NODE
-
-ares_addr_node* parseAsyncDNSServers(const std::string& serversOpt);
-
-#endif // HAVE_ARES_ADDR_NODE
 
 } // namespace aria2
 

--- a/src/AsyncNameResolverMan.cc
+++ b/src/AsyncNameResolverMan.cc
@@ -88,12 +88,7 @@ void AsyncNameResolverMan::startAsyncFamily(const std::string& hostname,
                                             Command* command)
 {
   asyncNameResolver_[numResolver_] =
-      std::make_shared<AsyncNameResolver>(family
-#ifdef HAVE_ARES_ADDR_NODE
-                                          ,
-                                          e->getAsyncDNSServers()
-#endif // HAVE_ARES_ADDR_NODE
-      );
+      std::make_shared<AsyncNameResolver>(family, servers_);
   asyncNameResolver_[numResolver_]->resolve(hostname);
   setNameResolverCheck(numResolver_, e, command);
 }
@@ -222,6 +217,7 @@ void configureAsyncNameResolverMan(AsyncNameResolverMan* asyncNameResolverMan,
   if (!net::getIPv6AddrConfigured() || option->getAsBool(PREF_DISABLE_IPV6)) {
     asyncNameResolverMan->setIPv6(false);
   }
+  asyncNameResolverMan->setServers(option->get(PREF_ASYNC_DNS_SERVER));
 }
 
 } // namespace aria2

--- a/src/AsyncNameResolverMan.h
+++ b/src/AsyncNameResolverMan.h
@@ -79,6 +79,8 @@ public:
   // Resets state. Also removes resolvers from DownloadEngine.
   void reset(DownloadEngine* e, Command* command);
 
+  void setServers(std::string servers) { servers_ = std::move(servers); }
+
 private:
   void startAsyncFamily(const std::string& hostname, int family,
                         DownloadEngine* e, Command* command);
@@ -88,6 +90,7 @@ private:
                                 Command* command);
 
   std::shared_ptr<AsyncNameResolver> asyncNameResolver_[2];
+  std::string servers_;
   size_t numResolver_;
   int resolverCheck_;
   bool ipv4_;

--- a/src/DownloadEngine.cc
+++ b/src/DownloadEngine.cc
@@ -104,9 +104,6 @@ DownloadEngine::DownloadEngine(std::unique_ptr<EventPoll> eventPoll)
 #ifdef ENABLE_BITTORRENT
       btRegistry_(make_unique<BtRegistry>()),
 #endif // ENABLE_BITTORRENT
-#ifdef HAVE_ARES_ADDR_NODE
-      asyncDNSServers_(nullptr),
-#endif // HAVE_ARES_ADDR_NODE
       dnsCache_(make_unique<DNSCache>()),
       option_(nullptr)
 {
@@ -115,12 +112,7 @@ DownloadEngine::DownloadEngine(std::unique_ptr<EventPoll> eventPoll)
   sessionId_.assign(&sessionId[0], &sessionId[sizeof(sessionId)]);
 }
 
-DownloadEngine::~DownloadEngine()
-{
-#ifdef HAVE_ARES_ADDR_NODE
-  setAsyncDNSServers(nullptr);
-#endif // HAVE_ARES_ADDR_NODE
-}
+DownloadEngine::~DownloadEngine() {}
 
 namespace {
 void executeCommand(std::deque<std::unique_ptr<Command>>& commands,
@@ -611,19 +603,6 @@ void DownloadEngine::setCheckIntegrityMan(
 {
   checkIntegrityMan_ = std::move(ciman);
 }
-
-#ifdef HAVE_ARES_ADDR_NODE
-void DownloadEngine::setAsyncDNSServers(ares_addr_node* asyncDNSServers)
-{
-  ares_addr_node* node = asyncDNSServers_;
-  while (node) {
-    ares_addr_node* next = node->next;
-    delete node;
-    node = next;
-  }
-  asyncDNSServers_ = asyncDNSServers;
-}
-#endif // HAVE_ARES_ADDR_NODE
 
 #ifdef ENABLE_WEBSOCKET
 void DownloadEngine::setWebSocketSessionMan(

--- a/src/DownloadEngine.h
+++ b/src/DownloadEngine.h
@@ -137,10 +137,6 @@ private:
 
   CUIDCounter cuidCounter_;
 
-#ifdef HAVE_ARES_ADDR_NODE
-  ares_addr_node* asyncDNSServers_;
-#endif // HAVE_ARES_ADDR_NODE
-
   std::unique_ptr<DNSCache> dnsCache_;
 
   std::unique_ptr<AuthConfigFactory> authConfigFactory_;
@@ -325,12 +321,6 @@ public:
   void setRefreshInterval(std::chrono::milliseconds interval);
 
   const std::string getSessionId() const { return sessionId_; }
-
-#ifdef HAVE_ARES_ADDR_NODE
-  void setAsyncDNSServers(ares_addr_node* asyncDNSServers);
-
-  ares_addr_node* getAsyncDNSServers() const { return asyncDNSServers_; }
-#endif // HAVE_ARES_ADDR_NODE
 
 #ifdef ENABLE_WEBSOCKET
   void setWebSocketSessionMan(std::unique_ptr<rpc::WebSocketSessionMan> wsman);

--- a/src/MultiUrlRequestInfo.cc
+++ b/src/MultiUrlRequestInfo.cc
@@ -272,11 +272,6 @@ int MultiUrlRequestInfo::prepare()
     clTlsContext->setVerifyPeer(option_->getAsBool(PREF_CHECK_CERTIFICATE));
     SocketCore::setClientTLSContext(clTlsContext);
 #endif
-#ifdef HAVE_ARES_ADDR_NODE
-    ares_addr_node* asyncDNSServers =
-        parseAsyncDNSServers(option_->get(PREF_ASYNC_DNS_SERVER));
-    e_->setAsyncDNSServers(asyncDNSServers);
-#endif // HAVE_ARES_ADDR_NODE
 
     std::string serverStatIf = option_->get(PREF_SERVER_STAT_IF);
     if (!serverStatIf.empty()) {

--- a/src/OptionHandlerFactory.cc
+++ b/src/OptionHandlerFactory.cc
@@ -99,15 +99,13 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     op->setChangeOptionForReserved(true);
     handlers.push_back(op);
   }
-#  if defined(HAVE_ARES_SET_SERVERS) && defined(HAVE_ARES_ADDR_NODE)
   {
     OptionHandler* op(new DefaultOptionHandler(
         PREF_ASYNC_DNS_SERVER, TEXT_ASYNC_DNS_SERVER, NO_DEFAULT_VALUE));
     op->addTag(TAG_ADVANCED);
     handlers.push_back(op);
   }
-#  endif // HAVE_ARES_SET_SERVERS && HAVE_ARES_ADDR_NODE
-#endif   // ENABLE_ASYNC_DNS
+#endif // ENABLE_ASYNC_DNS
   {
     OptionHandler* op(new BooleanOptionHandler(
         PREF_AUTO_FILE_RENAMING, TEXT_AUTO_FILE_RENAMING, A2_V_TRUE,

--- a/test/AsyncNameResolverTest.cc
+++ b/test/AsyncNameResolverTest.cc
@@ -11,43 +11,14 @@ namespace aria2 {
 class AsyncNameResolverTest : public CppUnit::TestFixture {
 
   CPPUNIT_TEST_SUITE(AsyncNameResolverTest);
-  CPPUNIT_TEST(testParseAsyncDNSServers);
   CPPUNIT_TEST_SUITE_END();
 
 public:
   void setUp() {}
 
   void tearDown() {}
-
-  void testParseAsyncDNSServers();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(AsyncNameResolverTest);
-
-void AsyncNameResolverTest::testParseAsyncDNSServers()
-{
-#ifdef HAVE_ARES_ADDR_NODE
-  in_addr ans4;
-  CPPUNIT_ASSERT_EQUAL((size_t)4, net::getBinAddr(&ans4, "192.168.0.1"));
-  in6_addr ans6;
-  CPPUNIT_ASSERT_EQUAL((size_t)16, net::getBinAddr(&ans6, "2001:db8::2:1"));
-
-  ares_addr_node* root;
-  root = parseAsyncDNSServers("192.168.0.1,2001:db8::2:1");
-  ares_addr_node* node = root;
-  CPPUNIT_ASSERT(node);
-  CPPUNIT_ASSERT_EQUAL(AF_INET, node->family);
-  CPPUNIT_ASSERT(memcmp(&ans4, &node->addr, sizeof(ans4)) == 0);
-  node = node->next;
-  CPPUNIT_ASSERT(node);
-  CPPUNIT_ASSERT_EQUAL(AF_INET6, node->family);
-  CPPUNIT_ASSERT(memcmp(&ans6, &node->addr, sizeof(ans6)) == 0);
-  for (node = root; node;) {
-    ares_addr_node* nextNode = node->next;
-    delete node;
-    node = nextNode;
-  }
-#endif // HAVE_ARES_ADDR_NODE
-}
 
 } // namespace aria2


### PR DESCRIPTION
Avoid deprecated functions by newer c-ares.  Now aria2 requires c-ares >= 1.16.0 to get ares_getaddrinfo.