### PR TITLE
fix: Remove redundant filepath separator when use applyDir()

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -2108,6 +2108,9 @@ std::string applyDir(const std::string& dir, const std::string& relPath)
       s += relPath;
     }
     else {
+      while (s.back() == '/' || s.back() == '\\') {
+        s.pop_back();
+      }
       s += "/";
       s += relPath;
     }


### PR DESCRIPTION
When user set a **dir** option ending with a filepath separator, there will be two separator between download dir and relative path.
This will result in loading task failure when reading input session file.
 
close #1661