### PR TITLE
Fix compile with libc++20 on mingw

### DIFF
--- a/src/gai_strerror.h
+++ b/src/gai_strerror.h
@@ -33,10 +33,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifdef __MINGW32__
-#  undef SIZE_MAX
-#endif // __MINGW32__
-
 #ifndef EAI_SYSTEM
 #  define EAI_SYSTEM -11 /* System error returned in `errno'.  */
 #endif


### PR DESCRIPTION
undef SIZE_MAX caused building aria2 with libc++20 to fail, because libc++ uses this definition internally.

ref:
https://github.com/mstorsjo/llvm-mingw/issues/460
https://github.com/llvm/llvm-project/pull/91798#discussion_r1795235794