### PR TITLE
Add deflate raw mode support

### DIFF
--- a/src/GZipDecodingStreamFilter.cc
+++ b/src/GZipDecodingStreamFilter.cc
@@ -48,6 +48,7 @@ GZipDecodingStreamFilter::GZipDecodingStreamFilter(
     : StreamFilter{std::move(delegate)},
       strm_{nullptr},
       finished_{false},
+      rawMode_{false},
       bytesProcessed_{0}
 {
 }
@@ -66,7 +67,8 @@ void GZipDecodingStreamFilter::init()
   strm_->next_in = Z_NULL;
 
   // initialize z_stream with gzip/zlib format auto detection enabled.
-  if (Z_OK != inflateInit2(strm_, 47)) {
+  // negative windowBits enables raw mode support.
+  if (Z_OK != inflateInit2(strm_, rawMode_ ? -15 : 47)) {
     throw DL_ABORT_EX("Initializing z_stream failed.");
   }
 }
@@ -105,6 +107,12 @@ GZipDecodingStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
       finished_ = true;
     }
     else if (ret != Z_OK && ret != Z_BUF_ERROR) {
+      if (!rawMode_) {
+        // reset in raw mode
+        rawMode_ = true;
+        init();
+        return transform(out, segment, inbuf, inlen);
+      }
       throw DL_ABORT_EX(fmt("libz::inflate() failed. cause:%s", strm_->msg));
     }
 

--- a/src/GZipDecodingStreamFilter.h
+++ b/src/GZipDecodingStreamFilter.h
@@ -49,6 +49,8 @@ private:
 
   bool finished_;
 
+  bool rawMode_;
+
   size_t bytesProcessed_;
 
   static const size_t OUTBUF_LENGTH = 16_k;


### PR DESCRIPTION
## Description
This PR fixes/supports raw mode of Deflate compression.

## Details
When request with `Accept-Encoding: deflate` HTTP header, some CDNs may have an unusual behavior, which responds with the content compressed in raw Deflate mode with `Content-Encoding: deflate` header. This causes aria2 abort download with error message `libz::inflate() failed. cause:incorrect header check`.

As [zlib Manual](https://www.zlib.net/manual.html) described:
 > ```c
 > EXTERN int ZEXPORT inflateInit2(z_streamp strm,
 >                                 int  windowBits);
 > ```
 > ... It should be in the range 8..15 for this version of the library.
 > ...
 > `windowBits` can also be –8..–15 for raw inflate. In this case, -windowBits determines the window size. inflate() will then process raw deflate data, not looking for a zlib or gzip header, not generating a check value, and not looking for any check values for comparison at the end of the stream.
 > ...
 > `windowBits` can also be greater than 15 for optional gzip decoding.


This PR tries to fix this issue by try decompress the content twice. The first trial is in normal mode, which is same as the old behavior. If the first trial fails, it will try re-initialiaze `GZipDecodingStreamFilter` class with `windowBits = -15`. Then, if the second trial is failed, aria2 will abort download, same as the old behavior.

## Related URLs / Issues
 - This PR fixes #1436
 - One of the sample URL: https://comment.bilibili.com/771495675.xml

## Test Result
On my laptop the fix passed test with `make -j2 check`:
```
PASS: aria2c
============================================================================
Testsuite summary for aria2 1.37.0
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
```
However, a new test file compressed in raw Deflate mode might be needed to add more coverage to this case. Please reach me if I need further actions.