### PR TITLE
Fix(build): Correct sed command for macOS during man page generation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,17 @@ AC_SUBST(LT_CURRENT, 0)
 AC_SUBST(LT_REVISION, 0)
 AC_SUBST(LT_AGE, 0)
 
+dnl Check for sed -i flag for in-place editing
+case "$host_os" in
+  darwin*)
+    SED_I_BAK="''"
+    ;;
+  *)
+    SED_I_BAK=""
+    ;;
+esac
+AC_SUBST(SED_I_BAK)
+
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_SRCDIR([src/a2io.h])
 AC_CONFIG_HEADERS([config.h])

--- a/doc/manual-src/ru/Makefile.am
+++ b/doc/manual-src/ru/Makefile.am
@@ -126,7 +126,7 @@ text:
 
 man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
-	sed -i -e '1i .\\" -*- mode: troff; coding: utf-8 -*-' $(BUILDDIR)/man/aria2c.1
+	sed -i $(SED_I_BAK) -e '1i .\\" -*- mode: troff; coding: utf-8 -*-' $(DESTDIR)$(man1dir)/aria2c.1
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 


### PR DESCRIPTION
This pull request resolves a build failure that occurs on macOS systems during the make process (m4 Pro).

Problem:

The build was failing near the end of the process due to an incorrect sed command syntax in the Russian man page generation script (doc/manual-src/ru/Makefile.am). The sed -i command for in-place editing requires a backup extension argument on macOS (e.g., sed -i ''), whereas on other systems like Linux, no argument is needed. This caused an error and halted the build for macOS users.

Solution:

1.  A check has been added to configure.ac to detect if the host OS is darwin (macOS).
2.  Based on the OS, a SED_I_BAK variable is substituted with the appropriate value ('' for macOS, empty for others).
3.  The doc/manual-src/ru/Makefile.am file has been updated to use the $(SED_I_BAK) variable in the sed command.

While the error manifested in the Russian documentation build, this fix prevents an error for users building on a macOS environment, m4 Pro - macOS Sequoia 15.5 (24F74)