### PR TITLE
Remove obsolete `#undef SIZE_MAX` from MinGW compatibility headers

### DIFF
--- a/src/gai_strerror.h
+++ b/src/gai_strerror.h
@@ -33,10 +33,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifdef __MINGW32__
-#  undef SIZE_MAX
-#endif // __MINGW32__
-
 #ifndef EAI_SYSTEM
 #  define EAI_SYSTEM -11 /* System error returned in `errno'.  */
 #endif

--- a/src/getaddrinfo.h
+++ b/src/getaddrinfo.h
@@ -33,10 +33,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-#ifdef __MINGW32__
-#  undef SIZE_MAX
-#endif // __MINGW32__
-
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif // HAVE_CONFIG_H

--- a/src/gettimeofday.h
+++ b/src/gettimeofday.h
@@ -36,10 +36,6 @@
 #ifndef _D_GETTIMEOFDAY_H
 #define _D_GETTIMEOFDAY_H 1
 
-#ifdef __MINGW32__
-#  undef SIZE_MAX
-#endif // __MINGW32__
-
 #ifdef HAVE_CONFIG_H
 #  include "config.h"
 #endif // HAVE_CONFIG_H


### PR DESCRIPTION
This PR removes obsolete unconditional `#undef SIZE_MAX` blocks from src/gettimeofday.h, src/getaddrinfo.h, and src/gai_strerror.h. Those lines were a long-ago workaround for a bundled gettext macro (circa 2008) that could cause a SIZE_MAX redefinition; aria2 no longer defines SIZE_MAX via configure/config.h, so the undef is unnecessary and now breaks builds with mingw-w64 GCC using the MCF thread model by preventing the standard headers from supplying SIZE_MAX. Removing the undef restores the expected behavior on modern MinGW toolchains, fixes the Windows build failures I observed, and is low risk (no runtime behavior changes); I validated the change by building with both posix and MCF thread models.