### PR TITLE
util: Fix upper bound in parseUIntNoThrow

### DIFF
--- a/src/util.cc
+++ b/src/util.cc
@@ -573,9 +573,9 @@ bool parseIntNoThrow(int32_t& res, const std::string& s, int base)
 
 bool parseUIntNoThrow(uint32_t& res, const std::string& s, int base)
 {
-  long int t;
-  if (parseLong(t, strtol, s, base) && t >= 0 &&
-      t <= std::numeric_limits<int32_t>::max()) {
+  unsigned long t;
+  if (parseLong(t, strtoul, s, base) && t >= 0 &&
+      t <= static_cast<unsigned long>(std::numeric_limits<uint32_t>::max())) {
     res = t;
     return true;
   }


### PR DESCRIPTION
parseUIntNoThrow writes to uint32_t but compared against std::numeric_limits<int32_t>::max(), rejecting valid values in (INT32_MAX, UINT32_MAX]. Compare against uint32_t max instead.