### PR TITLE
Avoid integer overflow in year 2038

### DIFF
--- a/src/ServerStatMan.cc
+++ b/src/ServerStatMan.cc
@@ -219,8 +219,8 @@ bool ServerStatMan::load(const std::string& filename)
       }
       sstat->setCounter(uintval);
     }
-    int32_t intval;
-    if (!util::parseIntNoThrow(intval, m[S_LAST_UPDATED])) {
+    int64_t intval;
+    if (!util::parseLLIntNoThrow(intval, m[S_LAST_UPDATED])) {
       continue;
     }
     sstat->setLastUpdated(Time(intval));


### PR DESCRIPTION
Avoid integer overflow in year 2038

See https://en.wikipedia.org/wiki/Year_2038_problem

This patch was done while reviewing potential year-2038 issues in openSUSE.