### PR TITLE
Fix build against Nettle 4.0

### DIFF
--- a/src/LibnettleMessageDigestImpl.cc
+++ b/src/LibnettleMessageDigestImpl.cc
@@ -36,6 +36,7 @@
 #include "MessageDigestImpl.h"
 
 #include <nettle/nettle-meta.h>
+#include <nettle/version.h>
 
 #include "Adler32MessageDigestImpl.h"
 
@@ -69,7 +70,11 @@ public:
   }
   virtual void digest(unsigned char* md) CXX11_OVERRIDE
   {
+#if NETTLE_VERSION_MAJOR > 3
+    hash->digest(ctx_.get(), md);
+#else
     hash->digest(ctx_.get(), getDigestLength(), md);
+#endif
   }
 
 private:


### PR DESCRIPTION
In Nettle 4.0, the *_digest functions no longer take the desired digest size as argument.

Thanks to @antonio-rojas for the patch.