### PR TITLE
Add SOCKS5 proxy support for HTTP/HTTPS/FTP/SFTP downloads

### DIFF
--- a/src/FeatureConfig.cc
+++ b/src/FeatureConfig.cc
@@ -88,6 +88,9 @@ uint16_t getDefaultPort(const std::string& protocol)
   else if (protocol == "sftp") {
     return 22;
   }
+  else if (protocol == "socks5" || protocol == "socks5h") {
+    return 1080;
+  }
   else {
     return 0;
   }

--- a/src/FtpInitiateConnectionCommand.cc
+++ b/src/FtpInitiateConnectionCommand.cc
@@ -60,6 +60,7 @@
 #include "FtpNegotiationConnectChain.h"
 #include "FtpTunnelRequestConnectChain.h"
 #include "HttpRequestConnectChain.h"
+#include "FtpSocksProxyConnectChain.h"
 #ifdef HAVE_LIBSSH2
 #  include "SftpNegotiationConnectChain.h"
 #  include "SftpNegotiationCommand.h"
@@ -84,7 +85,10 @@ std::unique_ptr<Command> FtpInitiateConnectionCommand::createNextCommandProxied(
 {
   std::string options;
   std::shared_ptr<SocketCore> pooledSocket;
-  std::string proxyMethod = resolveProxyMethod(getRequest()->getProtocol());
+  bool isSocksProxy = proxyRequest->getProtocol() == "socks5";
+  std::string proxyMethod = isSocksProxy
+                                ? V_TUNNEL
+                                : resolveProxyMethod(getRequest()->getProtocol());
 
   // sftp always use tunnel mode
   if (proxyMethod == V_GET) {
@@ -112,7 +116,10 @@ std::unique_ptr<Command> FtpInitiateConnectionCommand::createNextCommandProxied(
     auto c = make_unique<ConnectCommand>(getCuid(), getRequest(), proxyRequest,
                                          getFileEntry(), getRequestGroup(),
                                          getDownloadEngine(), getSocket());
-    if (proxyMethod == V_GET) {
+    if (isSocksProxy) {
+      c->setControlChain(std::make_shared<FtpSocksProxyConnectChain>());
+    }
+    else if (proxyMethod == V_GET) {
       // Use GET for FTP via HTTP proxy.
       getRequest()->setMethod(Request::METHOD_GET);
       c->setControlChain(std::make_shared<HttpRequestConnectChain>());

--- a/src/FtpSocksProxyConnectChain.h
+++ b/src/FtpSocksProxyConnectChain.h
@@ -1,0 +1,80 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#ifndef FTP_SOCKS_PROXY_CONNECT_CHAIN_H
+#define FTP_SOCKS_PROXY_CONNECT_CHAIN_H
+
+#include "ControlChain.h"
+#include "ConnectCommand.h"
+#include "DownloadEngine.h"
+#include "SocksProxyCommand.h"
+#include "FtpNegotiationCommand.h"
+#ifdef HAVE_LIBSSH2
+#  include "SftpNegotiationCommand.h"
+#endif // HAVE_LIBSSH2
+
+namespace aria2 {
+
+struct FtpSocksProxyConnectChain : public ControlChain<ConnectCommand*> {
+  FtpSocksProxyConnectChain() {}
+  virtual ~FtpSocksProxyConnectChain() {}
+  virtual int run(ConnectCommand* t, DownloadEngine* e) CXX11_OVERRIDE
+  {
+    auto c = make_unique<SocksProxyCommand>(
+        t->getCuid(), t->getRequest(), t->getFileEntry(), t->getRequestGroup(),
+        e, t->getProxyRequest(), t->getSocket(),
+        [](SocksProxyCommand* cmd) -> std::unique_ptr<Command> {
+#ifdef HAVE_LIBSSH2
+          if (cmd->getRequest()->getProtocol() == "sftp") {
+            return make_unique<SftpNegotiationCommand>(
+                cmd->getCuid(), cmd->getRequest(), cmd->getFileEntry(),
+                cmd->getRequestGroup(), cmd->getDownloadEngine(),
+                cmd->getSocket());
+          }
+#endif // HAVE_LIBSSH2
+          return make_unique<FtpNegotiationCommand>(
+              cmd->getCuid(), cmd->getRequest(), cmd->getFileEntry(),
+              cmd->getRequestGroup(), cmd->getDownloadEngine(),
+              cmd->getSocket());
+        });
+    c->setStatus(Command::STATUS_ONESHOT_REALTIME);
+    e->setNoWait(true);
+    e->addCommand(std::move(c));
+    return 0;
+  }
+};
+
+} // namespace aria2
+
+#endif // FTP_SOCKS_PROXY_CONNECT_CHAIN_H

--- a/src/HttpInitiateConnectionCommand.cc
+++ b/src/HttpInitiateConnectionCommand.cc
@@ -55,6 +55,7 @@
 #include "ConnectCommand.h"
 #include "HttpRequestConnectChain.h"
 #include "HttpProxyRequestConnectChain.h"
+#include "HttpSocksProxyConnectChain.h"
 
 namespace aria2 {
 
@@ -78,7 +79,10 @@ std::unique_ptr<Command> HttpInitiateConnectionCommand::createNextCommand(
         getDownloadEngine()->popPooledSocket(
             getRequest()->getHost(), getRequest()->getPort(),
             proxyRequest->getHost(), proxyRequest->getPort());
-    std::string proxyMethod = resolveProxyMethod(getRequest()->getProtocol());
+    bool isSocksProxy = proxyRequest->getProtocol() == "socks5";
+    std::string proxyMethod = isSocksProxy
+                                  ? V_TUNNEL
+                                  : resolveProxyMethod(getRequest()->getProtocol());
     if (!pooledSocket) {
       A2_LOG_INFO(fmt(MSG_CONNECTING_TO_SERVER, getCuid(), addr.c_str(), port));
       createSocket();
@@ -88,7 +92,10 @@ std::unique_ptr<Command> HttpInitiateConnectionCommand::createNextCommand(
       auto c = make_unique<ConnectCommand>(
           getCuid(), getRequest(), proxyRequest, getFileEntry(),
           getRequestGroup(), getDownloadEngine(), getSocket());
-      if (proxyMethod == V_TUNNEL) {
+      if (isSocksProxy) {
+        c->setControlChain(std::make_shared<HttpSocksProxyConnectChain>());
+      }
+      else if (proxyMethod == V_TUNNEL) {
         c->setControlChain(std::make_shared<HttpProxyRequestConnectChain>());
       }
       else if (proxyMethod == V_GET) {

--- a/src/HttpSocksProxyConnectChain.h
+++ b/src/HttpSocksProxyConnectChain.h
@@ -1,0 +1,75 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#ifndef HTTP_SOCKS_PROXY_CONNECT_CHAIN_H
+#define HTTP_SOCKS_PROXY_CONNECT_CHAIN_H
+
+#include "ControlChain.h"
+#include "ConnectCommand.h"
+#include "DownloadEngine.h"
+#include "SocksProxyCommand.h"
+#include "HttpRequestCommand.h"
+#include "HttpConnection.h"
+#include "SocketRecvBuffer.h"
+
+namespace aria2 {
+
+struct HttpSocksProxyConnectChain : public ControlChain<ConnectCommand*> {
+  HttpSocksProxyConnectChain() {}
+  virtual ~HttpSocksProxyConnectChain() {}
+  virtual int run(ConnectCommand* t, DownloadEngine* e) CXX11_OVERRIDE
+  {
+    auto c = make_unique<SocksProxyCommand>(
+        t->getCuid(), t->getRequest(), t->getFileEntry(), t->getRequestGroup(),
+        e, t->getProxyRequest(), t->getSocket(),
+        [](SocksProxyCommand* cmd) -> std::unique_ptr<Command> {
+          auto socketRecvBuffer =
+              std::make_shared<SocketRecvBuffer>(cmd->getSocket());
+          auto httpConnection = std::make_shared<HttpConnection>(
+              cmd->getCuid(), cmd->getSocket(), socketRecvBuffer);
+          return make_unique<HttpRequestCommand>(
+              cmd->getCuid(), cmd->getRequest(), cmd->getFileEntry(),
+              cmd->getRequestGroup(), httpConnection,
+              cmd->getDownloadEngine(), cmd->getSocket());
+        });
+    c->setStatus(Command::STATUS_ONESHOT_REALTIME);
+    e->setNoWait(true);
+    e->addCommand(std::move(c));
+    return 0;
+  }
+};
+
+} // namespace aria2
+
+#endif // HTTP_SOCKS_PROXY_CONNECT_CHAIN_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -110,6 +110,7 @@ SRCS =  \
 	FtpTunnelRequestCommand.cc FtpTunnelRequestCommand.h\
 	FtpTunnelRequestConnectChain.h\
 	FtpTunnelResponseCommand.cc FtpTunnelResponseCommand.h\
+	FtpSocksProxyConnectChain.h\
 	GenericParser.h\
 	GeomStreamPieceSelector.cc GeomStreamPieceSelector.h\
 	GroupId.cc GroupId.h\
@@ -126,6 +127,7 @@ SRCS =  \
 	HttpProxyRequestCommand.cc HttpProxyRequestCommand.h\
 	HttpProxyRequestConnectChain.h\
 	HttpProxyResponseCommand.cc HttpProxyResponseCommand.h\
+	HttpSocksProxyConnectChain.h\
 	HttpRequest.cc HttpRequest.h\
 	HttpRequestCommand.cc HttpRequestCommand.h\
 	HttpRequestConnectChain.h\
@@ -228,6 +230,7 @@ SRCS =  \
 	SingleFileAllocationIterator.cc SingleFileAllocationIterator.h\
 	SingletonHolder.h\
 	SinkStreamFilter.cc SinkStreamFilter.h\
+	SocksProxyCommand.cc SocksProxyCommand.h\
 	SocketBuffer.cc SocketBuffer.h\
 	SocketCore.cc SocketCore.h\
 	SocketRecvBuffer.cc SocketRecvBuffer.h\

--- a/src/OptionHandlerImpl.cc
+++ b/src/OptionHandlerImpl.cc
@@ -506,7 +506,9 @@ void HttpProxyOptionHandler::parseArg(Option& option,
   }
   else {
     std::string uri;
-    if (util::startsWith(optarg, "http://") ||
+    bool isSocks = util::startsWith(optarg, "socks5://") ||
+                   util::startsWith(optarg, "socks5h://");
+    if (isSocks || util::startsWith(optarg, "http://") ||
         util::startsWith(optarg, "https://") ||
         util::startsWith(optarg, "ftp://")) {
       uri = optarg;
@@ -519,14 +521,19 @@ void HttpProxyOptionHandler::parseArg(Option& option,
     if (!uri::parse(us, uri)) {
       throw DL_ABORT_EX(_("unrecognized proxy format"));
     }
-    us.protocol = "http";
+    if (isSocks) {
+      us.protocol = "socks5";
+    }
+    else {
+      us.protocol = "http";
+    }
     option.put(pref_, uri::construct(us));
   }
 }
 
 std::string HttpProxyOptionHandler::createPossibleValuesString() const
 {
-  return "[http://][USER:PASSWORD@]HOST[:PORT]";
+  return "[http://|socks5://|socks5h://][USER:PASSWORD@]HOST[:PORT]";
 }
 
 LocalFilePathOptionHandler::LocalFilePathOptionHandler(

--- a/src/SocksProxyCommand.cc
+++ b/src/SocksProxyCommand.cc
@@ -1,0 +1,322 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#include "SocksProxyCommand.h"
+
+#include <cassert>
+
+#include "Request.h"
+#include "DownloadEngine.h"
+#include "RequestGroup.h"
+#include "Option.h"
+#include "prefs.h"
+#include "SocketCore.h"
+#include "SocketRecvBuffer.h"
+#include "DlRetryEx.h"
+#include "DlAbortEx.h"
+#include "message.h"
+#include "fmt.h"
+#include "LogFactory.h"
+#include "Logger.h"
+
+namespace aria2 {
+
+namespace {
+const uint8_t SOCKS5_VERSION = 0x05;
+const uint8_t SOCKS5_AUTH_NONE = 0x00;
+const uint8_t SOCKS5_AUTH_USERPASS = 0x02;
+const uint8_t SOCKS5_AUTH_NO_ACCEPTABLE = 0xFF;
+const uint8_t SOCKS5_CMD_CONNECT = 0x01;
+const uint8_t SOCKS5_ATYP_DOMAINNAME = 0x03;
+const uint8_t SOCKS5_USERPASS_VERSION = 0x01;
+const uint8_t SOCKS5_REPLY_SUCCEEDED = 0x00;
+} // namespace
+
+SocksProxyCommand::SocksProxyCommand(
+    cuid_t cuid, const std::shared_ptr<Request>& req,
+    const std::shared_ptr<FileEntry>& fileEntry, RequestGroup* requestGroup,
+    DownloadEngine* e, const std::shared_ptr<Request>& proxyRequest,
+    const std::shared_ptr<SocketCore>& s,
+    NextCommandFactory nextCommandFactory)
+    : AbstractCommand(cuid, req, fileEntry, requestGroup, e, s),
+      proxyRequest_(proxyRequest),
+      recvBuffer_(std::make_shared<SocketRecvBuffer>(s)),
+      nextCommandFactory_(std::move(nextCommandFactory)),
+      state_(SOCKS_GREETING_SEND),
+      sendOffset_(0)
+{
+  setTimeout(std::chrono::seconds(getOption()->getAsInt(PREF_CONNECT_TIMEOUT)));
+  disableReadCheckSocket();
+  setWriteCheckSocket(getSocket());
+  buildGreeting();
+}
+
+SocksProxyCommand::~SocksProxyCommand() = default;
+
+bool SocksProxyCommand::sendData()
+{
+  while (sendOffset_ < sendBuf_.size()) {
+    ssize_t written = getSocket()->writeData(
+        sendBuf_.data() + sendOffset_, sendBuf_.size() - sendOffset_);
+    if (written == 0) {
+      setWriteCheckSocket(getSocket());
+      return false;
+    }
+    sendOffset_ += written;
+  }
+  return true;
+}
+
+bool SocksProxyCommand::recvData(size_t expect)
+{
+  if (recvBuffer_->getBufferLength() < expect) {
+    recvBuffer_->recv();
+    if (recvBuffer_->getBufferLength() < expect) {
+      setReadCheckSocket(getSocket());
+      return false;
+    }
+  }
+  return true;
+}
+
+void SocksProxyCommand::buildGreeting()
+{
+  const std::string& user = proxyRequest_->getUri();
+  bool hasAuth = !getOption()->get(PREF_ALL_PROXY_USER).empty();
+
+  sendBuf_.clear();
+  sendOffset_ = 0;
+  sendBuf_.push_back(SOCKS5_VERSION);
+  if (hasAuth) {
+    sendBuf_.push_back(2);
+    sendBuf_.push_back(SOCKS5_AUTH_NONE);
+    sendBuf_.push_back(SOCKS5_AUTH_USERPASS);
+  }
+  else {
+    sendBuf_.push_back(1);
+    sendBuf_.push_back(SOCKS5_AUTH_NONE);
+  }
+}
+
+void SocksProxyCommand::buildAuth()
+{
+  std::string user = getOption()->get(PREF_ALL_PROXY_USER);
+  std::string passwd = getOption()->get(PREF_ALL_PROXY_PASSWD);
+
+  sendBuf_.clear();
+  sendOffset_ = 0;
+  sendBuf_.push_back(SOCKS5_USERPASS_VERSION);
+  sendBuf_.push_back(static_cast<uint8_t>(user.size()));
+  sendBuf_.insert(sendBuf_.end(), user.begin(), user.end());
+  sendBuf_.push_back(static_cast<uint8_t>(passwd.size()));
+  sendBuf_.insert(sendBuf_.end(), passwd.begin(), passwd.end());
+}
+
+void SocksProxyCommand::buildConnect()
+{
+  const std::string& host = getRequest()->getHost();
+  uint16_t port = getRequest()->getPort();
+
+  sendBuf_.clear();
+  sendOffset_ = 0;
+  sendBuf_.push_back(SOCKS5_VERSION);
+  sendBuf_.push_back(SOCKS5_CMD_CONNECT);
+  sendBuf_.push_back(0x00); // RSV
+  sendBuf_.push_back(SOCKS5_ATYP_DOMAINNAME);
+  sendBuf_.push_back(static_cast<uint8_t>(host.size()));
+  sendBuf_.insert(sendBuf_.end(), host.begin(), host.end());
+  sendBuf_.push_back(static_cast<uint8_t>((port >> 8) & 0xFF));
+  sendBuf_.push_back(static_cast<uint8_t>(port & 0xFF));
+}
+
+void SocksProxyCommand::processGreetingResponse()
+{
+  const unsigned char* buf = recvBuffer_->getBuffer();
+  if (buf[0] != SOCKS5_VERSION) {
+    throw DL_ABORT_EX("SOCKS5 proxy returned unexpected version.");
+  }
+  uint8_t method = buf[1];
+  recvBuffer_->drain(2);
+
+  if (method == SOCKS5_AUTH_NONE) {
+    buildConnect();
+    state_ = SOCKS_CONNECT_SEND;
+  }
+  else if (method == SOCKS5_AUTH_USERPASS) {
+    buildAuth();
+    state_ = SOCKS_AUTH_SEND;
+  }
+  else {
+    throw DL_ABORT_EX("SOCKS5 proxy requires unsupported authentication.");
+  }
+}
+
+void SocksProxyCommand::processAuthResponse()
+{
+  const unsigned char* buf = recvBuffer_->getBuffer();
+  if (buf[0] != SOCKS5_USERPASS_VERSION || buf[1] != 0x00) {
+    throw DL_RETRY_EX("SOCKS5 proxy authentication failed.");
+  }
+  recvBuffer_->drain(2);
+  buildConnect();
+  state_ = SOCKS_CONNECT_SEND;
+}
+
+bool SocksProxyCommand::processConnectResponse()
+{
+  const unsigned char* buf = recvBuffer_->getBuffer();
+  size_t len = recvBuffer_->getBufferLength();
+
+  if (len < 5) {
+    return false;
+  }
+
+  if (buf[0] != SOCKS5_VERSION) {
+    throw DL_ABORT_EX("SOCKS5 proxy returned unexpected version in reply.");
+  }
+  if (buf[1] != SOCKS5_REPLY_SUCCEEDED) {
+    throw DL_RETRY_EX(
+        fmt("SOCKS5 proxy connect failed with status 0x%02x.", buf[1]));
+  }
+
+  size_t replyLen;
+  uint8_t atyp = buf[3];
+  if (atyp == 0x01) { // IPv4
+    replyLen = 10;
+  }
+  else if (atyp == 0x04) { // IPv6
+    replyLen = 22;
+  }
+  else if (atyp == 0x03) { // Domain name
+    replyLen = 7 + buf[4];
+  }
+  else {
+    throw DL_ABORT_EX("SOCKS5 proxy returned unknown address type.");
+  }
+
+  if (len < replyLen) {
+    return false;
+  }
+  recvBuffer_->drain(replyLen);
+  return true;
+}
+
+bool SocksProxyCommand::executeInternal()
+{
+  switch (state_) {
+  case SOCKS_GREETING_SEND:
+    if (!sendData()) {
+      addCommandSelf();
+      return false;
+    }
+    A2_LOG_INFO(fmt("CUID#%" PRId64
+                    " - SOCKS5 greeting sent to proxy %s:%d",
+                    getCuid(), proxyRequest_->getHost().c_str(),
+                    proxyRequest_->getPort()));
+    state_ = SOCKS_GREETING_RECV;
+    setReadCheckSocket(getSocket());
+    disableWriteCheckSocket();
+    addCommandSelf();
+    return false;
+
+  case SOCKS_GREETING_RECV:
+    if (!recvData(2)) {
+      addCommandSelf();
+      return false;
+    }
+    processGreetingResponse();
+    disableReadCheckSocket();
+    setWriteCheckSocket(getSocket());
+    addCommandSelf();
+    return false;
+
+  case SOCKS_AUTH_SEND:
+    if (!sendData()) {
+      addCommandSelf();
+      return false;
+    }
+    state_ = SOCKS_AUTH_RECV;
+    setReadCheckSocket(getSocket());
+    disableWriteCheckSocket();
+    addCommandSelf();
+    return false;
+
+  case SOCKS_AUTH_RECV:
+    if (!recvData(2)) {
+      addCommandSelf();
+      return false;
+    }
+    processAuthResponse();
+    disableReadCheckSocket();
+    setWriteCheckSocket(getSocket());
+    addCommandSelf();
+    return false;
+
+  case SOCKS_CONNECT_SEND:
+    if (!sendData()) {
+      addCommandSelf();
+      return false;
+    }
+    A2_LOG_INFO(fmt("CUID#%" PRId64
+                    " - SOCKS5 CONNECT request sent for %s:%d",
+                    getCuid(), getRequest()->getHost().c_str(),
+                    getRequest()->getPort()));
+    state_ = SOCKS_CONNECT_RECV;
+    setReadCheckSocket(getSocket());
+    disableWriteCheckSocket();
+    addCommandSelf();
+    return false;
+
+  case SOCKS_CONNECT_RECV: {
+    recvBuffer_->recv();
+    if (!processConnectResponse()) {
+      setReadCheckSocket(getSocket());
+      addCommandSelf();
+      return false;
+    }
+    A2_LOG_INFO(fmt("CUID#%" PRId64
+                    " - SOCKS5 tunnel established to %s:%d",
+                    getCuid(), getRequest()->getHost().c_str(),
+                    getRequest()->getPort()));
+    getDownloadEngine()->addCommand(nextCommandFactory_(this));
+    return true;
+  }
+  }
+
+  // Unreachable
+  assert(0);
+  return false;
+}
+
+} // namespace aria2

--- a/src/SocksProxyCommand.h
+++ b/src/SocksProxyCommand.h
@@ -1,0 +1,93 @@
+/* <!-- copyright */
+/*
+ * aria2 - The high speed download utility
+ *
+ * Copyright (C) 2006 Tatsuhiro Tsujikawa
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ *
+ * In addition, as a special exception, the copyright holders give
+ * permission to link the code of portions of this program with the
+ * OpenSSL library under certain conditions as described in each
+ * individual source file, and distribute linked combinations
+ * including the two.
+ * You must obey the GNU General Public License in all respects
+ * for all of the code used other than OpenSSL.  If you modify
+ * file(s) with this exception, you may extend this exception to your
+ * version of the file(s), but you are not obligated to do so.  If you
+ * do not wish to do so, delete this exception statement from your
+ * version.  If you delete this exception statement from all source
+ * files in the program, then also delete it here.
+ */
+/* copyright --> */
+#ifndef D_SOCKS_PROXY_COMMAND_H
+#define D_SOCKS_PROXY_COMMAND_H
+
+#include "AbstractCommand.h"
+
+#include <vector>
+#include <functional>
+
+namespace aria2 {
+
+class SocketRecvBuffer;
+
+class SocksProxyCommand : public AbstractCommand {
+public:
+  using NextCommandFactory =
+      std::function<std::unique_ptr<Command>(SocksProxyCommand*)>;
+
+  SocksProxyCommand(cuid_t cuid, const std::shared_ptr<Request>& req,
+                    const std::shared_ptr<FileEntry>& fileEntry,
+                    RequestGroup* requestGroup, DownloadEngine* e,
+                    const std::shared_ptr<Request>& proxyRequest,
+                    const std::shared_ptr<SocketCore>& s,
+                    NextCommandFactory nextCommandFactory);
+
+  virtual ~SocksProxyCommand();
+
+protected:
+  virtual bool executeInternal() CXX11_OVERRIDE;
+
+private:
+  enum State {
+    SOCKS_GREETING_SEND,
+    SOCKS_GREETING_RECV,
+    SOCKS_AUTH_SEND,
+    SOCKS_AUTH_RECV,
+    SOCKS_CONNECT_SEND,
+    SOCKS_CONNECT_RECV,
+  };
+
+  bool sendData();
+  bool recvData(size_t expect);
+  void buildGreeting();
+  void buildAuth();
+  void buildConnect();
+  void processGreetingResponse();
+  void processAuthResponse();
+  bool processConnectResponse();
+
+  std::shared_ptr<Request> proxyRequest_;
+  std::shared_ptr<SocketRecvBuffer> recvBuffer_;
+  NextCommandFactory nextCommandFactory_;
+  State state_;
+  std::vector<unsigned char> sendBuf_;
+  size_t sendOffset_;
+};
+
+} // namespace aria2
+
+#endif // D_SOCKS_PROXY_COMMAND_H

--- a/test/OptionHandlerTest.cc
+++ b/test/OptionHandlerTest.cc
@@ -285,7 +285,7 @@ void OptionHandlerTest::testHttpProxyOptionHandler()
   }
   catch (Exception& e) {
   }
-  CPPUNIT_ASSERT_EQUAL(std::string("[http://][USER:PASSWORD@]HOST[:PORT]"),
+  CPPUNIT_ASSERT_EQUAL(std::string("[http://|socks5://|socks5h://][USER:PASSWORD@]HOST[:PORT]"),
                        handler.createPossibleValuesString());
 
   handler.parse(option, "http://user%40:passwd%40@proxy:8080");
@@ -294,6 +294,26 @@ void OptionHandlerTest::testHttpProxyOptionHandler()
 
   handler.parse(option, "http://[::1]:8080");
   CPPUNIT_ASSERT_EQUAL(std::string("http://[::1]:8080/"),
+                       option.get(PREF_HTTP_PROXY));
+
+  handler.parse(option, "socks5://proxy:9050");
+  CPPUNIT_ASSERT_EQUAL(std::string("socks5://proxy:9050/"),
+                       option.get(PREF_HTTP_PROXY));
+
+  handler.parse(option, "socks5://proxy:1080");
+  CPPUNIT_ASSERT_EQUAL(std::string("socks5://proxy/"),
+                       option.get(PREF_HTTP_PROXY));
+
+  handler.parse(option, "socks5h://proxy:9050");
+  CPPUNIT_ASSERT_EQUAL(std::string("socks5://proxy:9050/"),
+                       option.get(PREF_HTTP_PROXY));
+
+  handler.parse(option, "socks5h://proxy:1080");
+  CPPUNIT_ASSERT_EQUAL(std::string("socks5://proxy/"),
+                       option.get(PREF_HTTP_PROXY));
+
+  handler.parse(option, "socks5://user:pass@proxy:9050");
+  CPPUNIT_ASSERT_EQUAL(std::string("socks5://user:pass@proxy:9050/"),
                        option.get(PREF_HTTP_PROXY));
 }
 


### PR DESCRIPTION
## Summary

Adds SOCKS5 proxy support to aria2's download pipeline. Users can now specify `socks5://` or `socks5h://` proxy URLs via `--all-proxy`, `--http-proxy`, `--https-proxy`, and `--ftp-proxy` options.

This addresses the long-standing feature request in #153 (opened 2013).

**Example usage:**
```
aria2c --all-proxy=socks5://127.0.0.1:1080 https://example.com/file.tar.gz
aria2c --all-proxy=socks5h://user:pass@proxy.example.com:1080 https://example.com/file.tar.gz
```

## Scope

This PR covers **HTTP, HTTPS, FTP, and SFTP downloads** through a SOCKS5 proxy. It is complementary to #1857, which targets BitTorrent UDP tracker/DHT connections.

## Implementation

- **`SocksProxyCommand`**: A state-machine command that handles the full SOCKS5 handshake (greeting → optional username/password authentication → CONNECT with DOMAINNAME address type) using non-blocking I/O on the existing `SocketCore` infrastructure.
- **`HttpSocksProxyConnectChain` / `FtpSocksProxyConnectChain`**: `ControlChain` adapters that wire `SocksProxyCommand` into the existing command pipeline, following the same pattern as `HttpProxyRequestConnectChain` / `FtpTunnelRequestConnectChain`.
- **`OptionHandlerImpl`**: Extended to accept `socks5://` and `socks5h://` proxy URIs (both are treated as SOCKS5 with remote DNS resolution via DOMAINNAME address type).
- **`FeatureConfig`**: Default port 1080 for `socks5` / `socks5h` schemes.
- **`HttpInitiateConnectionCommand` / `FtpInitiateConnectionCommand`**: Added branching to select the SOCKS5 command chain when the proxy scheme is `socks5`.

## Supported features

- [x] No authentication (`AUTH_NONE`)
- [x] Username/password authentication (RFC 1929) via `--all-proxy-user` / `--all-proxy-passwd`
- [x] Remote DNS resolution (DOMAINNAME address type)
- [x] HTTP, HTTPS, FTP, SFTP tunneling
- [x] IPv4 and IPv6 bind address replies

## Testing

Tested manually with an SSH SOCKS5 proxy (`ssh -D`) against `https://kernel.ubuntu.com/mainline/`:

```
$ aria2c --all-proxy='socks5://127.0.0.1:14080' https://kernel.ubuntu.com/mainline/
Download complete: /tmp/index.html
```

Ref: #153, #1857