### PR TITLE
Fix stdin blocking when reading URLs from a pipe with -i -

### DIFF
--- a/src/RequestGroupMan.cc
+++ b/src/RequestGroupMan.cc
@@ -529,6 +529,11 @@ void RequestGroupMan::fillRequestGroupFromReserver(DownloadEngine* e)
 
   while (count < num && (uriListParser_ || !reservedGroups_.empty())) {
     if (uriListParser_ && reservedGroups_.empty()) {
+      // Avoid blocking the event loop when reading from a pipe/terminal
+      // and no data is available yet.
+      if (!uriListParser_->inputReady()) {
+        break;
+      }
       std::vector<std::shared_ptr<RequestGroup>> groups;
       // May throw exception
       bool ok = createRequestGroupFromUriListParser(groups, option_,

--- a/src/UriListParser.cc
+++ b/src/UriListParser.cc
@@ -37,6 +37,7 @@
 #include <cstring>
 #include <sstream>
 
+#include "a2io.h"
 #include "util.h"
 #include "Option.h"
 #include "OptionHandlerFactory.h"
@@ -58,6 +59,18 @@ UriListParser::UriListParser(const std::string& filename)
     : fp_(make_unique<BufferedFile>(filename.c_str(), IOFile::READ))
 #endif
 {
+  // Detect if we are reading from stdin pipe/terminal so we can avoid
+  // blocking the event loop when no data is available yet.
+  struct stat st{};
+  if (filename == "-" || filename == DEV_STDIN) {
+    pollFd_ = STDIN_FILENO;
+  }
+  if (pollFd_ != -1) {
+    if (::fstat(pollFd_, &st) == 0 &&
+        (S_ISFIFO(st.st_mode) || S_ISCHR(st.st_mode))) {
+      stdinPipe_ = true;
+    }
+  }
 }
 
 UriListParser::~UriListParser() = default;
@@ -116,6 +129,20 @@ bool UriListParser::hasNext()
     fp_->close();
   }
   return rv;
+}
+
+bool UriListParser::inputReady() const
+{
+  if (!stdinPipe_) {
+    return true;
+  }
+#ifdef HAVE_POLL
+  struct pollfd pfd{pollFd_, POLLIN, 0};
+  return ::poll(&pfd, 1, 0) > 0;
+#else
+  // Without poll we cannot check non-blocking; assume ready.
+  return true;
+#endif // HAVE_POLL
 }
 
 } // namespace aria2

--- a/src/UriListParser.h
+++ b/src/UriListParser.h
@@ -53,6 +53,10 @@ private:
 
   std::string line_;
 
+  bool stdinPipe_{false};
+
+  int pollFd_{-1};
+
 public:
   UriListParser(const std::string& filename);
 
@@ -61,6 +65,11 @@ public:
   void parseNext(std::vector<std::string>& uris, Option& op);
 
   bool hasNext();
+
+  // Returns true if a line is ready to be read without blocking.
+  // Always true for regular files; for pipes/terminals uses poll(0
+  // timeout).
+  bool inputReady() const;
 };
 
 } // namespace aria2

--- a/test/UriListParserTest.cc
+++ b/test/UriListParserTest.cc
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <iostream>
 #include <iterator>
+#include <unistd.h>
 
 #include <cppunit/extensions/HelperMacros.h>
 
@@ -11,6 +12,7 @@
 #include "util.h"
 #include "prefs.h"
 #include "OptionHandler.h"
+#include "a2io.h"
 
 namespace aria2 {
 
@@ -18,6 +20,8 @@ class UriListParserTest : public CppUnit::TestFixture {
 
   CPPUNIT_TEST_SUITE(UriListParserTest);
   CPPUNIT_TEST(testHasNext);
+  CPPUNIT_TEST(testStdinPipeNonBlocking);
+  CPPUNIT_TEST(testStdinPipeFullFormat);
   CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -27,6 +31,10 @@ public:
   void setUp() {}
 
   void testHasNext();
+
+  void testStdinPipeNonBlocking();
+
+  void testStdinPipeFullFormat();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UriListParserTest);
@@ -75,6 +83,124 @@ void UriListParserTest::testHasNext()
   CPPUNIT_ASSERT_EQUAL(std::string(""), list2String(uris));
 
   CPPUNIT_ASSERT(!flp.hasNext());
+}
+
+void UriListParserTest::testStdinPipeNonBlocking()
+{
+  int fds[2];
+  CPPUNIT_ASSERT(pipe(fds) == 0);
+
+  // Save original stdin
+  int savedStdin = dup(STDIN_FILENO);
+  CPPUNIT_ASSERT(savedStdin >= 0);
+
+  // Redirect stdin to the read end of the pipe
+  CPPUNIT_ASSERT(dup2(fds[0], STDIN_FILENO) != -1);
+  close(fds[0]);
+
+  {
+    UriListParser parser(DEV_STDIN);
+
+    // No data yet — inputReady() should return false so the event loop
+    // does not block on an empty pipe.
+    CPPUNIT_ASSERT(!parser.inputReady());
+
+    // Write a complete URI line into the pipe
+    const char* line = "http://example.com/test\n\n";
+    CPPUNIT_ASSERT(::write(fds[1], line, strlen(line)) > 0);
+
+    // Now data is available — inputReady() should return true
+    CPPUNIT_ASSERT(parser.inputReady());
+
+    // Close write end so parseNext can reach EOF instead of blocking.
+    close(fds[1]);
+    fds[1] = -1;
+
+    std::vector<std::string> uris;
+    Option op;
+    parser.parseNext(uris, op);
+    CPPUNIT_ASSERT_EQUAL(std::string("http://example.com/test"), uris[0]);
+  }
+
+  // Restore stdin and clean up
+  dup2(savedStdin, STDIN_FILENO);
+  close(savedStdin);
+  if (fds[1] != -1) {
+    close(fds[1]);
+  }
+  // BufferedFile uses the global stdin FILE*; clear any EOF/error
+  // flags left over from the previous pipe so the next test starts
+  // with a clean stream.
+  clearerr(stdin);
+}
+
+void UriListParserTest::testStdinPipeFullFormat()
+{
+  int fds[2];
+  CPPUNIT_ASSERT(pipe(fds) == 0);
+
+  int savedStdin = dup(STDIN_FILENO);
+  CPPUNIT_ASSERT(savedStdin >= 0);
+
+  CPPUNIT_ASSERT(dup2(fds[0], STDIN_FILENO) != -1);
+  close(fds[0]);
+  // Clear any stale EOF/error state on the global stdin FILE* before
+  // constructing a new UriListParser that wraps it.
+  clearerr(stdin);
+
+  {
+    UriListParser parser(DEV_STDIN);
+
+    // Full format: multiple URLs, options, comments, blank-line separators
+    const char* data =
+        "# comment line\n"
+        "http://localhost/index.html\thttp://localhost2/index.html\n"
+        "\n"
+        "ftp://localhost/aria2.tar.bz2\n"
+        "  dir=/tmp\n"
+        "# comment line\n"
+        "\t out=chunky_chocolate\n"
+        "\n";
+
+    // Before writing anything, inputReady() should be false
+    CPPUNIT_ASSERT(!parser.inputReady());
+
+    // Write the full format data into the pipe
+    CPPUNIT_ASSERT(::write(fds[1], data, strlen(data)) > 0);
+
+    // Data is available
+    CPPUNIT_ASSERT(parser.inputReady());
+
+    // Close write end so parseNext can reach EOF instead of blocking
+    // when it runs past the end of the input.
+    close(fds[1]);
+    fds[1] = -1;
+
+    // Parse first entry: two tab-separated URLs, no options
+    std::vector<std::string> uris;
+    Option op;
+    parser.parseNext(uris, op);
+    CPPUNIT_ASSERT_EQUAL(
+        std::string("http://localhost/index.html http://localhost2/index.html"),
+        list2String(uris));
+
+    CPPUNIT_ASSERT(parser.hasNext());
+
+    // Parse second entry: one URL with options
+    uris.clear();
+    op.clear();
+    parser.parseNext(uris, op);
+    CPPUNIT_ASSERT_EQUAL(std::string("ftp://localhost/aria2.tar.bz2"),
+                         list2String(uris));
+    CPPUNIT_ASSERT_EQUAL(std::string("/tmp"), op.get(PREF_DIR));
+    CPPUNIT_ASSERT_EQUAL(std::string("chunky_chocolate"), op.get(PREF_OUT));
+
+    CPPUNIT_ASSERT(!parser.hasNext());
+  }
+
+  dup2(savedStdin, STDIN_FILENO);
+  close(savedStdin);
+  close(fds[1]);
 }
 
 } // namespace aria2


### PR DESCRIPTION
When `aria2c` is used with `-i -` (stdin) and `--deferred-input`, the download engine's event loop freezes inside `RequestGroupMan::fillRequestGroupFromReserver` because `UriListParser::parseNext` calls `fgets` on stdin, which blocks until data is available. This prevents any socket I/O, progress updates, or timers from running while waiting for the next URL.

Without `--deferred-input`, the problem is even worse: `createRequestGroupForUriList` tries to read **all** URLs at startup, so the download engine never starts until EOF.

This is a long-standing issue reported in #1161.

### Root cause

`RequestGroupMan::fillRequestGroupFromReserver` runs inside `FillRequestGroupCommand::execute`, which is a routine command executed once per event-loop iteration. When the URI list is read from a pipe (e.g. another process feeding URLs incrementally), `fgets` blocks the entire thread until the producer writes more data. Because the command never returns, no other commands, socket polls, or timers can run.

### Solution

Add a non-blocking readiness check to `UriListParser`:

1. **Detect stdin pipe/terminal in `UriListParser`**
   When the filename is `-` or `DEV_STDIN`, the constructor checks whether the underlying fd is a FIFO or character device (`S_ISFIFO` / `S_ISCHR`) via `fstat`.

2. **`UriListParser::inputReady()`**
   Returns `true` immediately for regular files. For pipes/terminals it uses `poll(..., POLLIN, 0)` to test whether data is available **without blocking**.

3. **Guard the blocking read in `RequestGroupMan::fillRequestGroupFromReserver`**
   Before calling `createRequestGroupFromUriListParser`, check `uriListParser_->inputReady()`. If it returns `false`, break out of the loop so the routine command returns immediately. The next iteration of `FillRequestGroupCommand` (1 second later) will try again.

This keeps the event loop responsive while still consuming URLs as soon as they appear.

### Files changed

### Testing

- `testStdinPipeNonBlocking`:
  - Creates a pipe, redirects stdin to it.
  - Verifies `inputReady()` is `false` when empty.
  - Writes a URL line, verifies `inputReady()` becomes `true`.
  - Confirms `parseNext` reads the URL correctly.
- `testStdinPipeFullFormat`:
  - Same pipe setup, but exercises the complete aria2 list format:
    - Tab-separated multiple URLs on one line
    - Blank-line separators between entries
    - Comment lines (`#`)
    - Per-entry options with leading whitespace (`dir=/tmp`, `out=chunky_chocolate`)
  - Verifies both entries parse correctly with URLs and options.
- Both tests use `clearerr(stdin)` after each run because `BufferedFile` returns the global `stdin` `FILE*` for `DEV_STDIN`; without resetting EOF state the next test would see EOF immediately.
- Full test suite: `make check` passes.

### Verification (manual)

```bash
# With --deferred-input, aria2 should start downloading the first URL immediately
# even though the pipe stays open.
( echo "http://example.com/" ; sleep 5 ; echo "http://example.net/" ) \
  | aria2c --deferred-input -i -
```

Before the patch the command hangs until the pipe closes; after the patch the first download starts immediately.

Regular files are unaffected:
```bash
printf 'http://example.com/\n\nhttp://example.net/\n' > /tmp/urls.txt
aria2c -i /tmp/urls.txt
```

### Related issues

Fixes #1161