### PR TITLE
Show private flag in --show-files output

### DIFF
--- a/src/bittorrent_helper.h
+++ b/src/bittorrent_helper.h
@@ -354,6 +354,7 @@ void print(Output& o, const std::shared_ptr<DownloadContext>& dctx)
     o.printf("Created By: %s\n", torrentAttrs->createdBy.c_str());
   }
   o.printf("Mode: %s\n", getModeString(torrentAttrs->mode));
+  o.printf("Private: %s\n", torrentAttrs->privateTorrent ? "yes" : "no");
   o.write("Announce:\n");
   for (std::vector<std::vector<std::string>>::const_iterator
            tierIter = torrentAttrs->announceList.begin(),


### PR DESCRIPTION
`aria2c -S` or `--show-files` already parses the torrent's private flag internally (`TorrentAttribute::privateTorrent`), but it does not display it in the output.

This patch adds a `Private: yes/no` line to the BitTorrent file information so that users can immediately verify whether a torrent is marked as private.

Example output:

```bash
$ aria2c --show-files private.torrent
>>> Printing the contents of file 'private.torrent'...
*** BitTorrent File Information ***
Mode: single
Private: yes
Announce:
 <removed>
Info Hash: <removed>
Piece Length: 16KiB
The Number of Pieces: 1
Total Length: 57B (57)
Name: testfile.bin
Magnet URI: magnet:?<removed>
Files:
```

Fixes #2297.