### PR TITLE
add a missing default value

### DIFF
--- a/doc/manual-src/en/aria2c.rst
+++ b/doc/manual-src/en/aria2c.rst
@@ -1647,6 +1647,7 @@ Advanced Options
    :option:`--allow-overwrite=true, <--allow-overwrite>` download always starts from
    scratch. This will be useful for users behind proxy server which
    disables resume.
+   Default: ``false``
 
 .. option:: --save-session=<FILE>
 


### PR DESCRIPTION
`--remove-control-file` starts as false according to the source code