### PR TITLE
Retry SSL/TLS handshake failures

### DIFF
--- a/src/SocketCore.cc
+++ b/src/SocketCore.cc
@@ -1016,7 +1016,7 @@ bool SocketCore::tlsHandshake(TLSContext* tlsctx, const std::string& hostname)
 
     if (rv == TLS_ERR_ERROR) {
       // Damn those error.
-      throw DL_ABORT_EX(fmt("SSL/TLS handshake failure: %s",
+      throw DL_RETRY_EX(fmt("SSL/TLS handshake failure: %s",
                             handshakeError.empty()
                                 ? tlsSession_->getLastErrorString().c_str()
                                 : handshakeError.c_str()));


### PR DESCRIPTION
SSL handshake failures were skipping `--max-tries` and bailing
immediately.  Swapped DL_ABORT_EX for DL_RETRY_EX in SocketCore.cc
so they get retried like any other transient error.

Fixes #1399.